### PR TITLE
🦈 IMP: Better Static Evaluation Bounds

### DIFF
--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -255,8 +255,12 @@ namespace StockDory
                 }
                 //endregion
 
-                const int32_t staticEvaluation = ttHit ? storedEntry.Evaluation : Evaluation::Evaluate<Color>();
+                //region Static Evaluation
+                const int32_t staticEvaluation = ttHit ?
+                        StaticEvaluationTT<Color>(storedEntry) : Evaluation::Evaluate<Color>();
                 Stack[ply].StaticEvaluation = staticEvaluation;
+                //endregion
+
                 const bool checked = Board.Checked<Color>();
                 bool improving = false;
 
@@ -554,7 +558,21 @@ namespace StockDory
                     TTable[hash] = entry;
             }
 
+            template<Color Color>
+            static inline int32_t StaticEvaluationTT(const EngineEntry& entry)
+            {
+                if (entry.Type == Exact) return entry.Evaluation;
 
+                const int32_t staticEvaluation = Evaluation::Evaluate<Color>();
+
+                if (staticEvaluation > entry.Evaluation && entry.Type == BetaCutoff    )
+                    return staticEvaluation;
+
+                if (staticEvaluation < entry.Evaluation && entry.Type == AlphaUnchanged)
+                    return staticEvaluation;
+
+                return entry.Evaluation;
+            }
 
     };
 

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -565,11 +565,8 @@ namespace StockDory
 
                 const int32_t staticEvaluation = Evaluation::Evaluate<Color>();
 
-                if (staticEvaluation > entry.Evaluation && entry.Type == BetaCutoff    )
-                    return staticEvaluation;
-
-                if (staticEvaluation < entry.Evaluation && entry.Type == AlphaUnchanged)
-                    return staticEvaluation;
+                if ((staticEvaluation > entry.Evaluation && entry.Type == BetaCutoff    ) ||
+                    (staticEvaluation < entry.Evaluation && entry.Type == AlphaUnchanged)) return staticEvaluation;
 
                 return entry.Evaluation;
             }


### PR DESCRIPTION
### 🎯 Summary

This PR intends to refine the existing behavior concerning determining the static evaluation whenever a transposition table hit (`ttHit`) occurs. In a nutshell, it provides trendy bounds in case the previous search might have under or overestimated the position due to search windows. 

Previously, whenever `ttHit = true`, the evaluation stored in the transposition table entry was used. With this change, that evaluation is only used when either the entry was of type `EXACT` or if the evaluation directly from the neural network doesn't match the trend proposed by the stored transposition table entry evaluation. 

If the trend is similar, we take a bold step further and purposely assume that the search may have underestimated or overestimated the position and that we should veer toward the respective extremes. This allows for more aggressive pruning in these positions in a heuristically-safe manner. 

### 👏 Acknowledgements
- **[Rak Laptudirm](https://github.com/raklaptudirm)**: This clever idea has been initially suggested by Rak, so it's only fair he deserves the full creative credit. Kudos, Rak! 🙌

### 📈 ELO
**[STC](http://tests.findingchess.com/test/98/)**:
```
ELO   | 50.21 +- 16.29 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1080 W: 405 L: 250 D: 425
```
**[LTC](http://tests.findingchess.com/test/99/)**:
```
ELO   | 44.26 +- 14.79 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1168 W: 392 L: 244 D: 532
```