### PR TITLE
🦈 IMP: Prefetching Transposition Table Entries

### DIFF
--- a/src/Backend/TranspositionTable.h
+++ b/src/Backend/TranspositionTable.h
@@ -57,7 +57,7 @@ namespace StockDory
 
             inline void Prefetch(const ZobristHash hash) const
             {
-                _mm_prefetch(&Internal[fastrange64(hash, Count)], _MM_HINT_T0);
+                _mm_prefetch(reinterpret_cast<const char*>(&Internal[fastrange64(hash, Count)]), _MM_HINT_T0);
             }
 
             [[nodiscard]]

--- a/src/Backend/TranspositionTable.h
+++ b/src/Backend/TranspositionTable.h
@@ -10,6 +10,8 @@
 #include <algorithm>
 #include <execution>
 
+#include <xmmintrin.h>
+
 #include "Type/Zobrist.h"
 
 #include "../External/fastrange.h"
@@ -51,6 +53,11 @@ namespace StockDory
             inline const T& operator [](const ZobristHash hash) const
             {
                 return Internal[fastrange64(hash, Count)];
+            }
+
+            inline void Prefetch(const ZobristHash hash) const
+            {
+                _mm_prefetch(&Internal[fastrange64(hash, Count)], _MM_HINT_T0);
             }
 
             [[nodiscard]]

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -451,15 +451,12 @@ namespace StockDory
                     if (seeEvaluation > beta) return seeEvaluation;
                     //endregion
 
-                    constexpr MoveType MT = NNUE | ZOBRIST;
-
-                    PreviousState state = Board.Move<MT>(move.From(), move.To(), move.Promotion());
-                    Nodes++;
+                    const PreviousState state = EngineMove<false>(move);
 
                     int32_t evaluation =
                             -Q<OColor, Pv>(ply + 1, depth - 1, -beta, -alpha);
 
-                    Board.UndoMove<MT>(state, move.From(), move.To());
+                    EngineUndoMove<false>(state, move);
 
                     //region Handle Evaluation
                     if (evaluation <= bestEvaluation) continue;
@@ -521,7 +518,11 @@ namespace StockDory
                 const PreviousState state = Board.Move<MT>(move.From(), move.To(), move.Promotion());
                 Nodes++;
 
-                if (UpdateHistory) Repetition.Push(Board.Zobrist());
+                const ZobristHash hash = Board.Zobrist();
+
+                TTable.Prefetch(hash);
+
+                if (UpdateHistory) Repetition.Push(hash);
 
                 return state;
             }


### PR DESCRIPTION
### 🎯 Summary

This PR aims to improve memory access performance by a notable amount. This is done by prefetching the Transposition Table Entry couple instructions before it is needed. The CPU fetches it into the `L1` cache (as specified by the Prefetch hint) in parallel with the instructions that would run just before the entry is needed so that when it is required, it may be taken instantly from the L1 cache (high-speed access). 

### 👏 Acknowledgements
- **[Jay Honnold](https://github.com/jhonnold)**: Jay initially suggested this for StockNemo; however, due to the nature of the .NET Runtime and its tendency to move memory around, the prefetching wasn't practical (and never gained ELO). This changes in StockDory's C++ World. Awesome suggestion, Jay! 🙌

### 📈 ELO
**[STC](http://findingchess.shaheryarsohail.com/test/68/)**:
```
ELO   | 12.71 +- 7.53 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4760 W: 1474 L: 1300 D: 1986
```
**[LTC](http://findingchess.shaheryarsohail.com/test/69/)**:
```
ELO   | 14.66 +- 7.98 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3888 W: 1121 L: 957 D: 1810
```