### PR TITLE
A small LMR refactor

### DIFF
--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -334,11 +334,10 @@ namespace StockDory
                         if (i >= LMRFullSearchThreshold && lmr) {
                             uint8_t r = LogarithmicReductionTable::Get(depth, i);
 
-                            if (!Pv) r++;
+                            r += !Pv;
+                            r += !improving;
 
-                            if (!improving) r++;
-
-                            int16_t reducedDepth = static_cast<int16_t>(std::max(depth - r, 1));
+                            int16_t reducedDepth = std::max<int16_t>(depth - r, 1);
 
                             evaluation = -AlphaBeta<OColor, false, false>
                                     (ply + 1, reducedDepth, -alpha - 1, -alpha);


### PR DESCRIPTION
No need for static_cast<int16_t>(std::max(depth - r, 1)) It can be simplified into std::max<int16_t>(depth - r, 1) which casts it using the template.

if (!Pv) or if(!Improving) can be simplified into: r += !Pv and r += !improving.