### PR TITLE
🦈 IMP: Dynamic NMP Formula based on Static Evaluation

### DIFF
--- a/src/Engine/EngineParameter.h
+++ b/src/Engine/EngineParameter.h
@@ -19,7 +19,7 @@ constexpr uint8_t MaxDepth = 128;
 constexpr uint8_t MaxMove  = 218;
 
 constexpr uint8_t NullMoveDepth            = 3  ;
-constexpr uint8_t NullMoveEvaluationMargin = 150;
+constexpr uint8_t NullMoveEvaluationMargin = 180;
 
 constexpr uint16_t AspirationBound = 3500;
 constexpr uint8_t  AspirationSize  = 16  ;

--- a/src/Engine/EngineParameter.h
+++ b/src/Engine/EngineParameter.h
@@ -18,7 +18,8 @@ constexpr int32_t Draw     = 0           ;
 constexpr uint8_t MaxDepth = 128;
 constexpr uint8_t MaxMove  = 218;
 
-constexpr uint8_t NullMoveDepth = 3;
+constexpr uint8_t NullMoveDepth            = 3  ;
+constexpr uint8_t NullMoveEvaluationMargin = 180;
 
 constexpr uint16_t AspirationBound = 3500;
 constexpr uint8_t  AspirationSize  = 16  ;

--- a/src/Engine/EngineParameter.h
+++ b/src/Engine/EngineParameter.h
@@ -18,10 +18,7 @@ constexpr int32_t Draw     = 0           ;
 constexpr uint8_t MaxDepth = 128;
 constexpr uint8_t MaxMove  = 218;
 
-constexpr uint8_t NullMoveReduction         = 4;
-constexpr uint8_t NullMoveDepth             = 2;
-constexpr uint8_t NullMoveScalingFactor     = 3;
-constexpr uint8_t NullMoveScalingCorrection = 1;
+constexpr uint8_t NullMoveDepth = 3;
 
 constexpr uint16_t AspirationBound = 3500;
 constexpr uint8_t  AspirationSize  = 16  ;

--- a/src/Engine/EngineParameter.h
+++ b/src/Engine/EngineParameter.h
@@ -19,7 +19,7 @@ constexpr uint8_t MaxDepth = 128;
 constexpr uint8_t MaxMove  = 218;
 
 constexpr uint8_t NullMoveDepth            = 3  ;
-constexpr uint8_t NullMoveEvaluationMargin = 180;
+constexpr uint8_t NullMoveEvaluationMargin = 150;
 
 constexpr uint16_t AspirationBound = 3500;
 constexpr uint8_t  AspirationSize  = 16  ;

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -488,7 +488,7 @@ namespace StockDory
                 const auto reductionStep   = static_cast<int16_t>(depth / NullMoveDepth);
                 const auto reductionFactor = static_cast<int16_t>((staticEvaluation - beta) / NullMoveEvaluationMargin);
                 const auto reduction       = static_cast<int16_t>(NullMoveDepth + reductionStep   +
-                                                std::min<int16_t>(NullMoveDepth, reductionFactor) * improving);
+                                                std::min<int16_t>(NullMoveDepth, reductionFactor) + improving);
 
                 PreviousStateNull state = Board.Move();
 

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -484,7 +484,7 @@ namespace StockDory
                 constexpr enum Color OColor = Opposite(Color);
 
                 const auto reductionStep   = static_cast<int16_t>(depth / NullMoveDepth);
-                const auto reductionFactor = static_cast<int16_t>((staticEvaluation - beta) / 180);
+                const auto reductionFactor = static_cast<int16_t>((staticEvaluation - beta) / NullMoveEvaluationMargin);
                 const auto reduction       = static_cast<int16_t>(NullMoveDepth + reductionStep +
                                                 std::min<int16_t>(NullMoveDepth, reductionFactor));
 

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -483,7 +483,7 @@ namespace StockDory
 
                 constexpr enum Color OColor = Opposite(Color);
 
-                const auto reductionStep   = static_cast<int16_t>(depth / NullMoveDepth);
+                const auto reductionStep   = static_cast<int16_t>(depth / (NullMoveDepth - 1));
                 const auto reductionFactor = static_cast<int16_t>((staticEvaluation - beta) / NullMoveEvaluationMargin);
                 const auto reduction       = static_cast<int16_t>(NullMoveDepth + reductionStep +
                                                 std::min<int16_t>(NullMoveDepth, reductionFactor));

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -277,7 +277,7 @@ namespace StockDory
                     //endregion
 
                     //region Null Move Pruning
-                    if (NMP<Color, Root>(ply, depth, staticEvaluation, beta, improving)) return beta;
+                    if (NMP<Color, Root>(ply, depth, staticEvaluation, beta)) return beta;
                     //endregion
                 } else if (checked) {
                     //region Check Extension
@@ -477,9 +477,7 @@ namespace StockDory
             }
 
             template<Color Color, bool Root>
-            inline bool NMP(const uint8_t ply, const int16_t depth,
-                            const int32_t staticEvaluation, const int32_t beta,
-                            const bool improving)
+            inline bool NMP(const uint8_t ply, const int16_t depth, const int32_t staticEvaluation, const int32_t beta)
             {
                 if (Root || depth < NullMoveDepth || staticEvaluation < beta) return false;
 
@@ -487,8 +485,8 @@ namespace StockDory
 
                 const auto reductionStep   = static_cast<int16_t>(depth / NullMoveDepth);
                 const auto reductionFactor = static_cast<int16_t>((staticEvaluation - beta) / NullMoveEvaluationMargin);
-                const auto reduction       = static_cast<int16_t>(NullMoveDepth + reductionStep   +
-                                                std::min<int16_t>(NullMoveDepth, reductionFactor) + improving);
+                const auto reduction       = static_cast<int16_t>(NullMoveDepth + reductionStep +
+                                                std::min<int16_t>(NullMoveDepth, reductionFactor));
 
                 PreviousStateNull state = Board.Move();
 

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -277,7 +277,7 @@ namespace StockDory
                     //endregion
 
                     //region Null Move Pruning
-                    if (NMP<Color, Root>(ply, depth, staticEvaluation, beta)) return beta;
+                    if (NMP<Color, Root>(ply, depth, staticEvaluation, beta, improving)) return beta;
                     //endregion
                 } else if (checked) {
                     //region Check Extension
@@ -477,7 +477,9 @@ namespace StockDory
             }
 
             template<Color Color, bool Root>
-            inline bool NMP(const uint8_t ply, const int16_t depth, const int32_t staticEvaluation, const int32_t beta)
+            inline bool NMP(const uint8_t ply, const int16_t depth,
+                            const int32_t staticEvaluation, const int32_t beta,
+                            const bool improving)
             {
                 if (Root || depth < NullMoveDepth || staticEvaluation < beta) return false;
 
@@ -485,8 +487,8 @@ namespace StockDory
 
                 const auto reductionStep   = static_cast<int16_t>(depth / NullMoveDepth);
                 const auto reductionFactor = static_cast<int16_t>((staticEvaluation - beta) / NullMoveEvaluationMargin);
-                const auto reduction       = static_cast<int16_t>(NullMoveDepth + reductionStep +
-                                                std::min<int16_t>(NullMoveDepth, reductionFactor));
+                const auto reduction       = static_cast<int16_t>(NullMoveDepth + reductionStep   +
+                                                std::min<int16_t>(NullMoveDepth, reductionFactor) + improving);
 
                 PreviousStateNull state = Board.Move();
 

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -483,7 +483,7 @@ namespace StockDory
 
                 constexpr enum Color OColor = Opposite(Color);
 
-                const auto reductionStep   = static_cast<int16_t>(depth / (NullMoveDepth - 1));
+                const auto reductionStep   = static_cast<int16_t>(depth / NullMoveDepth);
                 const auto reductionFactor = static_cast<int16_t>((staticEvaluation - beta) / NullMoveEvaluationMargin);
                 const auto reduction       = static_cast<int16_t>(NullMoveDepth + reductionStep +
                                                 std::min<int16_t>(NullMoveDepth, reductionFactor));

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -488,7 +488,7 @@ namespace StockDory
                 const auto reductionStep   = static_cast<int16_t>(depth / NullMoveDepth);
                 const auto reductionFactor = static_cast<int16_t>((staticEvaluation - beta) / NullMoveEvaluationMargin);
                 const auto reduction       = static_cast<int16_t>(NullMoveDepth + reductionStep   +
-                                                std::min<int16_t>(NullMoveDepth, reductionFactor) + improving);
+                                                std::min<int16_t>(NullMoveDepth, reductionFactor) * improving);
 
                 PreviousStateNull state = Board.Move();
 


### PR DESCRIPTION
### 🎯 Summary

This PR improves the NMP Formula by basing it on depth, static evaluation, and beta rather than depth only. Furthermore, a condition is added to the heuristic so that it only applies Null Move Pruning when according to the static evaluation, the position is already far better than what was hoped to achieve (beta). 

The new formula considers the difference between the better-than-beta static evaluation and beta to be a factor in the calculation done. Should the difference be extremely large, it is reasonable to say that even with more play between us after the free Null Move, the opponent will likely never be able to improve their position. Furthermore, the reduction step linearly increases with a far less slope than depth to give the opponent a reasonable chance at higher depths to improve their position, but not a completely unnecessary one, allowing the search to remain at the same pace.

### 👏 Acknowledgements
- **[Rafid](https://github.com/rafid-dev)**: Rafid made the pull request to implement this new formula in StockDory, based on its usage in other engines such as Stockfish, Ethereal, and Alexandria. A welcomed contribution! 🙌

### 📈 ELO
**[STC](http://tests.findingchess.com/test/108/)**:
```
ELO   | 15.32 +- 8.34 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3744 W: 1134 L: 969 D: 1641
```
**[LTC](http://tests.findingchess.com/test/110/)**:
```
ELO   | 14.16 +- 7.77 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 3928 W: 1085 L: 925 D: 1918
```