### PR TITLE
🐟 NEW: 50 Move Rule Draw Check & Faster Repetition Draw Check

### DIFF
--- a/src/Engine/RepetitionHistory.h
+++ b/src/Engine/RepetitionHistory.h
@@ -39,12 +39,16 @@ namespace StockDory
             }
 
             [[nodiscard]]
-            constexpr inline bool Found(const ZobristHash hash) const
+            constexpr inline bool Found(const ZobristHash hash, const uint8_t halfMoveCounter) const
             {
                 uint8_t count = 0;
                 for (uint16_t i = CurrentIndex - 1; i != 0xFFFF; i--) {
-                    if (Internal[i] == hash) count++;
-                    if (count > 2) return true;
+                    if (i < CurrentIndex - 1 - halfMoveCounter) return false;
+
+                    if (Internal[i] == hash) {
+                        count++;
+                        if (count > 2) return true;
+                    }
                 }
 
                 return false;

--- a/src/Engine/RepetitionHistory.h
+++ b/src/Engine/RepetitionHistory.h
@@ -39,16 +39,12 @@ namespace StockDory
             }
 
             [[nodiscard]]
-            constexpr inline bool Found(const ZobristHash hash, const uint8_t halfMoveCounter) const
+            constexpr inline bool Found(const ZobristHash hash) const
             {
                 uint8_t count = 0;
                 for (uint16_t i = CurrentIndex - 1; i != 0xFFFF; i--) {
-                    if (i < CurrentIndex - 1 - halfMoveCounter) return false;
-
-                    if (Internal[i] == hash) {
-                        count++;
-                        if (count > 2) return true;
-                    }
+                    if (Internal[i] == hash) count++;
+                    if (count > 2) return true;
                 }
 
                 return false;

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -212,7 +212,7 @@ namespace StockDory
                 if (!Root) {
                     if (Stack[ply].HalfMoveCounter >= 100) return Draw;
 
-                    if (Repetition.Found(hash, Stack[ply].HalfMoveCounter)) return Draw;
+                    if (Repetition.Found(hash)) return Draw;
 
                     const uint8_t pieceCount = Count(~Board[NAC]);
 

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -212,7 +212,7 @@ namespace StockDory
                 if (!Root) {
                     if (Stack[ply].HalfMoveCounter >= 100) return Draw;
 
-                    if (Repetition.Found(hash)) return Draw;
+                    if (Repetition.Found(hash, Stack[ply].HalfMoveCounter)) return Draw;
 
                     const uint8_t pieceCount = Count(~Board[NAC]);
 

--- a/src/Terminal/BenchHash.h
+++ b/src/Terminal/BenchHash.h
@@ -42,7 +42,7 @@ namespace StockDory
 
                     const Board             board   (Positions[i]);
                     const RepetitionHistory history (board.Zobrist());
-                    Search<NoLogger> search(board, infinite, history);
+                    Search<NoLogger> search(board, infinite, history, 0);
 
                     const TP start = std::chrono::high_resolution_clock::now();
                     search.IterativeDeepening(BenchDepth);

--- a/src/Terminal/UCI/UCIInterface.h
+++ b/src/Terminal/UCI/UCIInterface.h
@@ -206,7 +206,7 @@ namespace StockDory
                     const std::string fen      = strutil::join(fenToken, " ");
                     MainBoard       = Board(fen);
                     MainHistory     = RepetitionHistory(MainBoard.Zobrist());
-                    HalfMoveCounter = std::stoi(fenToken[5]);
+                    HalfMoveCounter = std::stoi(fenToken[4]);
                     moveStrIndex = 8;
                 } else if (strutil::compare_ignore_case(args[0], "startpos")) {
                     MainBoard       = Board();

--- a/src/Terminal/UCI/UCISearch.h
+++ b/src/Terminal/UCI/UCISearch.h
@@ -74,9 +74,9 @@ namespace StockDory
             UCISearch() = default;
 
             explicit UCISearch(const Board& board, const StockDory::TimeControl& timeControl,
-                               const RepetitionHistory& repetitionHistory)
+                               const RepetitionHistory& repetitionHistory, const uint8_t halfMoveCounter)
             {
-                EngineSearch = Search(board, timeControl, repetitionHistory);
+                EngineSearch = Search(board, timeControl, repetitionHistory, halfMoveCounter);
             }
 
             void Start(const uint8_t depth)


### PR DESCRIPTION
### 🎯 Summary

This PR implements a new 50 Move Rule Draw Check into the engine. With these changes, the half-move counter is read from the FEN provided to us over the UCI protocol and then used during the engine's search (updating accordingly) to detect lines leading to 50 move rule draw with the goal of avoiding them if they aren't beneficial for us.

Furthermore, using the 50-move rule, the current repetition checking has been improved by using the half-move counter as a hard limit for backward repetition history probing (after the half-move counter is reset, whether due to a capture move or a pawn move, the previous positions become unreachable hence repetition cannot happen). This is a speedup for deep searches & long games. 

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://tests.findingchess.com/test/132/)**:
```
ELO   | 3.14 +- 2.43 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 43568 W: 12331 L: 11937 D: 19300
```
**[LTC](http://tests.findingchess.com/test/133/)**:
```
ELO   | 4.27 +- 3.42 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 20416 W: 5389 L: 5138 D: 9889
```