### PR TITLE
🦈 IMP: Move Iteration respecting History Bonus

### DIFF
--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -339,8 +339,6 @@ namespace StockDory
 
                             if (!improving) r++;
 
-                            if (move.Promotion() != NAP) r++;
-
                             int16_t reducedDepth = static_cast<int16_t>(std::max(depth - r, 1));
 
                             evaluation = -AlphaBeta<OColor, false, false>

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -312,7 +312,7 @@ namespace StockDory
                 const bool    lmp               = !Root && !checked && depth <= LMPDepthThreshold;
                 const bool    lmr               = depth >= LMRDepthThreshold && !checked;
                 const int32_t historyBonus      = depth * depth;
-                const uint8_t historyFactor     = std::min(depth / 3, 1);
+                const uint8_t historyFactor     = std::max(depth / 3, 1);
 
                 uint8_t quietMoveCount = 0;
                 for (uint8_t i = 0; i < moves.Count(); i++) {


### PR DESCRIPTION
### 🎯 Summary

This PR improves the history bonus applied for a beta cutoff move by having it depend on how later on the move was found to be the best. This is because if the move was found much later on, the history score of that move should be increased much more, and the score of all the moves that came before it should also be decreased much more depending on how early they were.

There are some caveats to this that need to be investigated since the moves are fairly early on in the list; should they turn out not to be the best, they would face serious score loss. But the hope is that it all balances out should they become relevant later on.

The formula change:
```diff
- HistoryBonus = Depth * Depth;
+ HistoryBonus = Depth * Depth + MoveIteration * MAX(Depth / 3, 1);
```

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://tests.findingchess.com/test/138/)**:
```
ELO   | 6.56 +- 4.85 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10640 W: 2981 L: 2780 D: 4879
```
**[LTC](http://tests.findingchess.com/test/139/)**:
```
ELO   | 3.36 +- 2.68 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 32992 W: 8602 L: 8283 D: 16107
```