### PR TITLE
🦈 IMP: Allocate more thinking time for Search

### DIFF
--- a/src/Engine/TimeControl.h
+++ b/src/Engine/TimeControl.h
@@ -39,7 +39,12 @@ namespace StockDory
             Milliseconds Time = ZeroTime;
 
             constexpr static uint8_t TPartition = 20;
-            constexpr static uint8_t IPartition = 2 ;
+            constexpr static uint8_t Overhead   = 10;
+
+            constexpr static uint8_t IPartitionN = 3;
+            constexpr static uint8_t IPartitionD = 4;
+            constexpr static uint8_t TDeltaN     = 3;
+            constexpr static uint8_t TDeltaD     = 4;
 
         public:
             TimeControl() = default;
@@ -61,11 +66,13 @@ namespace StockDory
                 Time += oT / TPartition;
 
                 if (timeData.MovesToGo > 0)
-                    Time = std::max(Time, (oT / timeData.MovesToGo) - Milliseconds(100));
+                    Time = std::max(Time, oT / timeData.MovesToGo);
 
-                Time += oI / IPartition;
+                Time += oI * IPartitionN / IPartitionD;
 
-                if (oT - Milliseconds(1000) > tT) Time += (oT - tT) / TPartition;
+                if (oT - Milliseconds(1000) > tT) Time += (oT - tT) * TDeltaN / TDeltaD;
+
+                Time -= Milliseconds(Overhead);
             }
 
             inline void Start()


### PR DESCRIPTION
### 🎯 Summary

This PR increases the amount of time allocated to search for the best move in a game against opponents. This allows the engine more time to hit that extra depth in some games and proves to be beneficial, all while still ensuring no time losses occur. 

This is a small change, with an effort to improve time control. Proper time control is much needed in StockDory, and contributions are welcomed for that. 

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://tests.findingchess.com/test/157/)**:
```
ELO   | 4.95 +- 3.90 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 16560 W: 4624 L: 4388 D: 7548
```
**[LTC](http://tests.findingchess.com/test/158/)**:
```
ELO   | 2.61 +- 1.87 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 67200 W: 17312 L: 16808 D: 33080
```