### PR TITLE
🦈 IMP: Improve Transposition Table Entry Alignment

### DIFF
--- a/src/Engine/EngineEntry.h
+++ b/src/Engine/EngineEntry.h
@@ -26,9 +26,9 @@ namespace StockDory
     {
 
         ZobristHash     Hash       = 0;
-        uint8_t         Depth      = 0;
         int32_t         Evaluation = 0;
         Move            Move       = ::Move();
+        uint8_t         Depth      = 0;
         EngineEntryType Type       = Invalid;
 
     };

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -405,9 +405,9 @@ namespace StockDory
                 //region Transposition Table Insertion
                 auto entry = EngineEntry {
                     .Hash       = hash,
-                    .Depth      = static_cast<uint8_t>(depth),
                     .Evaluation = bestEvaluation,
                     .Move       = ttEntryType != AlphaUnchanged ? bestMove : ttMove,
+                    .Depth      = static_cast<uint8_t>(depth),
                     .Type       = ttEntryType
                 };
                 InsertEntry(hash, entry);


### PR DESCRIPTION
### 🎯 Summary

This PR reorders the data stored in a Search-used Transposition Table Entry in order of decreasing the size of the type, leading to better alignment. In turn, better alignment allows more entries to be inserted into the Transposition Table.

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://tests.findingchess.com/test/194/)**:
```
ELO   | 3.66 +- 2.94 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 28120 W: 7556 L: 7260 D: 13304
```
**[LTC](http://tests.findingchess.com/test/195/)**:
```
ELO   | 3.74 +- 3.00 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 25240 W: 6335 L: 6063 D: 12842
```