### PR TITLE
🦈 IMP: Compile same architecture networks from Testing Framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,20 @@
 ifeq ($(OS),Windows_NT)
     CP = powershell cp
-	EXTENSION = .exe
+    RM = powershell rm
+    EXTENSION = .exe
 else
     CP = cp
-	EXTENSION = 
+    RM = rm
+    EXTENSION =
 endif
 
 all: openbench
 
 openbench:
+ifdef EVALFILE
+	$(RM) -rf src/Engine/Model/* && \
+	$(CP) $(EVALFILE) src/Engine/Model/
+endif
 	cmake -B RB -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G Ninja && \
 	cmake --build RB --config Release && \
 	$(CP) RB/StockDory$(EXTENSION) StockDory$(EXTENSION)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ifeq ($(OS),Windows_NT)
-    CP = powershell cp
-    RM = powershell rm
+    CP = powershell -Command "Copy-Item"
+    RM = powershell -Command "Remove-Item -Recurse -Force"
     EXTENSION = .exe
 else
     CP = cp
@@ -12,7 +12,7 @@ all: openbench
 
 openbench:
 ifdef EVALFILE
-	$(RM) -rf src/Engine/Model/* && \
+	$(RM) src/Engine/Model/* && \
 	$(CP) $(EVALFILE) src/Engine/Model/
 endif
 	cmake -B RB -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -G Ninja && \


### PR DESCRIPTION
### 🎯 Summary

This PR changes the Makefile to allow it to handle the `EVALFILE` argument passed by the testing framework. Properly handled, it allows the network to be passed directly to the framework and avoids extra branch creation step on GitHub.

### 👏 Acknowledgements
NA

### 📈 ELO
NA