### PR TITLE
🦈 IMP: Improve Time Checking

### DIFF
--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -198,7 +198,7 @@ namespace StockDory
             int32_t AlphaBeta(const uint8_t ply, int16_t depth, int32_t alpha, int32_t beta)
             {
                 //region Out of Time & Force Stop
-                if (Stop || ((Nodes & 16383) == 0 && TC.Finished<true>())) throw SearchStopException();
+                if (Stop || ((Nodes & 4095) == 0 && TC.Finished<true>())) throw SearchStopException();
                 //endregion
 
                 constexpr enum Color OColor = Opposite(Color);

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -198,7 +198,7 @@ namespace StockDory
             int32_t AlphaBeta(const uint8_t ply, int16_t depth, int32_t alpha, int32_t beta)
             {
                 //region Out of Time & Force Stop
-                if (Stop || ((Nodes & 4095) && TC.Finished<true>())) throw SearchStopException();
+                if (Stop || ((Nodes & 16383) == 0 && TC.Finished<true>())) throw SearchStopException();
                 //endregion
 
                 constexpr enum Color OColor = Opposite(Color);

--- a/src/Engine/Time/TimeControl.h
+++ b/src/Engine/Time/TimeControl.h
@@ -12,7 +12,7 @@ namespace StockDory
 {
 
     using MS = std::chrono::milliseconds;
-    using TP = std::chrono::time_point<std::chrono::high_resolution_clock>;
+    using TP = std::chrono::time_point<std::chrono::steady_clock>;
 
     class TimeControl
     {
@@ -32,14 +32,14 @@ namespace StockDory
             TimeControl() = default;
 
             explicit TimeControl(const uint64_t optimal, const uint64_t actual, const bool optimizable = false)
-            : Origin(std::chrono::high_resolution_clock::now()),
+            : Origin(std::chrono::steady_clock::now()),
               OptimalTime(MS(optimal)),
                ActualTime(MS(actual )),
               Optimizable(optimizable) {}
 
             void Start()
             {
-                Origin = std::chrono::high_resolution_clock::now();
+                Origin = std::chrono::steady_clock::now();
             }
 
             [[nodiscard]]
@@ -72,7 +72,7 @@ namespace StockDory
             [[nodiscard]]
             inline MS Elapsed() const
             {
-                return std::chrono::duration_cast<MS>(std::chrono::high_resolution_clock::now() - Origin);
+                return std::chrono::duration_cast<MS>(std::chrono::steady_clock::now() - Origin);
             }
 
     };

--- a/src/Terminal/BenchHash.h
+++ b/src/Terminal/BenchHash.h
@@ -27,6 +27,8 @@ namespace StockDory
         public:
             static void Run()
             {
+                using BTP = std::chrono::time_point<std::chrono::high_resolution_clock>;
+
                 uint64_t nodes = 0;
                 TimeControl infinite = TimeManager::Default();
 
@@ -42,9 +44,9 @@ namespace StockDory
                     const RepetitionHistory history (board.Zobrist());
                     Search<NoLogger> search (board, infinite, history, 0);
 
-                    const TP start = std::chrono::high_resolution_clock::now();
+                    const BTP start = std::chrono::high_resolution_clock::now();
                     search.IterativeDeepening(BenchDepth);
-                    const TP stop  = std::chrono::high_resolution_clock::now();
+                    const BTP stop  = std::chrono::high_resolution_clock::now();
 
                     nodes += search.NodesSearched();
                     time  += std::chrono::duration_cast<MS>(stop - start);


### PR DESCRIPTION
### 🎯 Summary

This PR intends to improve the time checking done in StockDory. Previously, we checked for time at almost every node in our main search. Now, we check for time only every 4096 nodes. Furthermore, it makes more sense that we use a steady clock instead of the high-resolution clock. 

### 👏 Acknowledgements
- **[Connor](https://github.com/connormcmonigle)**: These changes were mostly suggested by Connor so it makes sense that he gets the creative credit for this PR. Thanks, Connor! 🙌

### 📈 ELO
**[STC](http://tests.findingchess.com/test/275/)**:
```
ELO   | 9.60 +- 6.20 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6336 W: 1753 L: 1578 D: 3005
```
**[LTC](http://tests.findingchess.com/test/277/)**:
```
ELO   | 4.53 +- 4.47 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 11120 W: 2743 L: 2598 D: 5779
```