### PR TITLE
🦈 IMP: Remove QSearch Limit & Increase Repetition History Storage

### DIFF
--- a/src/Engine/RepetitionHistory.h
+++ b/src/Engine/RepetitionHistory.h
@@ -18,7 +18,7 @@ namespace StockDory
     {
 
         private:
-            std::array<ZobristHash, 1024> Internal = {};
+            std::array<ZobristHash, 4096> Internal = {};
 
             uint16_t CurrentIndex = 0;
 

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -240,7 +240,7 @@ namespace StockDory
                 //endregion
 
                 //region Q Jump
-                if (depth <= 0) return Q<Color, Pv>(ply, MaxDepth / 4, alpha, beta);
+                if (depth <= 0) return Q<Color, Pv>(ply, alpha, beta);
                 //endregion
 
                 //region Zobrist Hash
@@ -317,7 +317,7 @@ namespace StockDory
 
                     //region Razoring
                     if (depth == 1 && staticEvaluation + RazoringEvaluationThreshold < alpha)
-                        return Q<Color, false>(ply, MaxDepth / 4, alpha, beta);
+                        return Q<Color, false>(ply, alpha, beta);
                     //endregion
 
                     //region Null Move Pruning
@@ -458,9 +458,9 @@ namespace StockDory
             }
 
             template<Color Color, bool Pv>
-            int32_t Q(const uint8_t ply, const int16_t depth, int32_t alpha, int32_t beta)
+            int32_t Q(const uint8_t ply, int32_t alpha, int32_t beta)
             {
-                constexpr enum Color OColor     = Opposite(Color);
+                constexpr enum Color OColor = Opposite(Color);
 
                 //region Selective Depth Change
                 if (Pv) SelectiveDepth = std::max(SelectiveDepth, ply);
@@ -505,8 +505,7 @@ namespace StockDory
 
                     const PreviousState state = EngineMove<false>(move, ply);
 
-                    int32_t evaluation =
-                            -Q<OColor, Pv>(ply + 1, depth - 1, -beta, -alpha);
+                    int32_t evaluation = -Q<OColor, Pv>(ply + 1, -beta, -alpha);
 
                     EngineUndoMove<false>(state, move);
 


### PR DESCRIPTION
### 🎯 Summary

The QSearch limit currently is effectively set to `32`. In a real chess game, there are no more than `30` captures possible, before a guaranteed result (draw). Thus, this is a non-functional change. Furthermore, to prevent any long game crashes, the Repetition History Storage is increased to `4096`. This uses 32KB memory instead of 8KB, but that's acceptable.

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://tests.findingchess.com/test/894/)**:
```
ELO   | 0.49 +- 2.21 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 48536 W: 12527 L: 12459 D: 23550
```
**[LTC](http://tests.findingchess.com/test/895/)**:
```
ELO   | 1.47 +- 2.89 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 26720 W: 6506 L: 6393 D: 13821
```