### PR TITLE
🦈 IMP: Add a King SEE Value

### DIFF
--- a/src/Engine/SEE.h
+++ b/src/Engine/SEE.h
@@ -20,7 +20,7 @@ namespace StockDory
 
         private:
             constexpr static std::array<uint16_t, 7> Internal = {
-                    82, 337, 365, 477, 1025, 0, 0
+                    82, 337, 365, 477, 1025, 30000, 0
             };
 
         public:


### PR DESCRIPTION
### 🎯 Summary

The current SEE values used to approximate SEE are missing a value for the King Piece. While typically not required, this value can be a good addition for future accurate SEE algorithms. This PR adds that value.

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://tests.findingchess.com/test/897/)**:
```
ELO   | 1.21 +- 2.79 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 30504 W: 7910 L: 7804 D: 14790
```
**[LTC](http://tests.findingchess.com/test/900/)**:
```
ELO   | 0.36 +- 2.02 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 53968 W: 12899 L: 12843 D: 28226
```