### PR TITLE
🦈 IMP: Accurate SEE (Static Exchange Evaluation)

### DIFF
--- a/src/Backend/Board.h
+++ b/src/Backend/Board.h
@@ -479,6 +479,23 @@ namespace StockDory
                 return pin;
             }
 
+            [[nodiscard]]
+            constexpr inline BitBoard SquareAttackers(const Square sq, const BitBoard occ) const
+            {
+                BitBoard attackers = (AttackTable::Pawn  [White][sq] &  BB[Black][Pawn  ]) |
+                                     (AttackTable::Pawn  [Black][sq] &  BB[White][Pawn  ]) |
+                                     (AttackTable::Knight       [sq] & (BB[White][Knight]  | BB[Black][Knight])) |
+                                     (AttackTable::King         [sq] & (BB[White][King  ]  | BB[Black][King  ])) ;
+
+                attackers |= AttackTable::Sliding[BlackMagicFactory::MagicIndex(Bishop, sq, occ)] &
+                             (BB[White][Bishop] | BB[Black][Bishop] | BB[White][Queen] | BB[Black][Queen]);
+
+                attackers |= AttackTable::Sliding[BlackMagicFactory::MagicIndex(Rook  , sq, occ)] &
+                             (BB[White][Rook  ] | BB[Black][Rook  ] | BB[White][Queen] | BB[Black][Queen]);
+
+                return attackers;
+            }
+
             constexpr inline PreviousStateNull Move()
             {
                 auto state = PreviousStateNull(EnPassantSquare());

--- a/src/Engine/SEE.h
+++ b/src/Engine/SEE.h
@@ -34,20 +34,6 @@ namespace StockDory
             }
 
         public:
-            static inline int32_t Approximate(const Board& board, const Move move)
-            {
-                Piece from = board[move.From()].Piece();
-                Piece to   = board[move.  To()].Piece();
-
-                if (from == Pawn && move.To() == board.EnPassantSquare()) to = Pawn;
-
-                int32_t value = Internal[to];
-
-                if (move.Promotion() != NAP) value += Internal[move.Promotion()] - Internal[Pawn];
-
-                return value - Internal[from];
-            }
-
             static inline bool Accurate(const Board& board, const Move move, const int32_t threshold)
             {
                 if (Unchecked(board, move)) return true;

--- a/src/Engine/SEE.h
+++ b/src/Engine/SEE.h
@@ -58,7 +58,7 @@ namespace StockDory
                 value -= Internal[board[move.From()].Piece()];
                 if (value >= 0) return true;
 
-                BitBoard occ = (~board[NAC] ^ BitBoard(move.From())) | BitBoard(move.To());
+                BitBoard occ = (~board[NAC] ^ FromSquare(move.From())) | FromSquare(move.To());
                 BitBoard att = board.SquareAttackers(move.To(), occ);
 
                 BitBoard diagonal = board.PieceBoard<White>(Bishop) | board.PieceBoard<Black>(Bishop) |
@@ -85,7 +85,7 @@ namespace StockDory
                         break;
                     }
 
-                    occ ^= BitBoard(ToSquare(us & board.PieceBoard(piece, Opposite(ctm))));
+                    occ ^= FromSquare(ToSquare(us & board.PieceBoard(piece, Opposite(ctm))));
 
                     if (piece == Pawn || piece == Bishop || piece == Queen) {
                         const uint32_t idx = BlackMagicFactory::MagicIndex(Bishop, move.To(), occ);

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -497,10 +497,7 @@ namespace StockDory
                     const Move move = moves[i];
 
                     //region SEE Pruning
-                    const int32_t see = SEE::Approximate(Board, move);
-
-                    const int32_t seeEvaluation = staticEvaluation + see;
-                    if (seeEvaluation > beta) return seeEvaluation;
+                    if (!SEE::Accurate(Board, move, 0)) continue;
                     //endregion
 
                     const PreviousState state = EngineMove<false>(move, ply);


### PR DESCRIPTION
### 🎯 Summary

This PR removes the Approximation function used for Static Exchange Evaluation (SEE) pruning with an Accurate function. The goal is that this allows for a deeper understanding of good and bad captures, avoiding bad captures that may seem good initially.

The algorithm used is the [SWAP Algorithm](https://www.chessprogramming.org/SEE_-_The_Swap_Algorithm).

The implementation changes the SEE Pruning currently done in QSearch to use the `Accurate` function instead of the `Approximate` one.

### 👏 Acknowledgements
- **[Jay Honnold](https://github.com/jhonnold)**: The algorithm implementation is largely inspired by Jay's implementation of the algorithm. Kudos, Jay. 🙌

### 📈 ELO
**[STC](http://tests.findingchess.com/test/918/)**:
```
ELO   | 21.32 +- 9.75 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2480 W: 706 L: 554 D: 1220
```
**[LTC](http://tests.findingchess.com/test/920/)**:
```
ELO   | 18.56 +- 8.99 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2848 W: 782 L: 630 D: 1436
```