### PR TITLE
🦈 IMP: SEE (Static Exchange Evaluation) Policy

### DIFF
--- a/src/Engine/Move/Policy.h
+++ b/src/Engine/Move/Policy.h
@@ -76,8 +76,8 @@ namespace StockDory
             inline int32_t CaptureScore(const Board& board, const Move move) const
             {
                 if (SEE::Accurate(board, move, 0))
-                     return         MvvLva[board[move.To()].Piece()][Piece]  *  1000;
-                else return 8000 - (MvvLva[board[move.To()].Piece()][Piece]) * -1000;
+                     return MvvLva[board[move.To()].Piece()][Piece] * 1000;
+                else return MvvLva[board[move.To()].Piece()][Piece] * 300 ;
             }
 
     };

--- a/src/Engine/Move/Policy.h
+++ b/src/Engine/Move/Policy.h
@@ -10,6 +10,7 @@
 #include "../../Backend/Board.h"
 
 #include "../EngineParameter.h"
+#include "../SEE.h"
 #include "HistoryTable.h"
 
 namespace StockDory
@@ -62,12 +63,21 @@ namespace StockDory
                 if (Promotion != NAP)  return PromotionPriority[Promotion];
 
                 if (CaptureOnly || board[move.To()].Piece() != NAP)
-                     return MvvLva[board[move.To()].Piece()][Piece] * 10000;
+                    return CaptureScore<Piece>(board, move);
 
                 if (move == KillerOne) return 900000;
                 if (move == KillerTwo) return 800000;
 
                 return historyTable.Get(Piece, Color, move.To());
+            }
+
+            template<Piece Piece>
+            [[nodiscard]]
+            inline int32_t CaptureScore(const Board& board, const Move move) const
+            {
+                if (SEE::Accurate(board, move, 0))
+                     return MvvLva[board[move.To()].Piece()][Piece] * 1000;
+                else return MvvLva[board[move.To()].Piece()][Piece] * 300 ;
             }
 
     };

--- a/src/Engine/Move/Policy.h
+++ b/src/Engine/Move/Policy.h
@@ -76,8 +76,8 @@ namespace StockDory
             inline int32_t CaptureScore(const Board& board, const Move move) const
             {
                 if (SEE::Accurate(board, move, 0))
-                     return MvvLva[board[move.To()].Piece()][Piece] * 1000;
-                else return MvvLva[board[move.To()].Piece()][Piece] * 300 ;
+                     return         MvvLva[board[move.To()].Piece()][Piece]  *  1000;
+                else return 8000 - (MvvLva[board[move.To()].Piece()][Piece]) * -1000;
             }
 
     };


### PR DESCRIPTION
### 🎯 Summary

This PR uses the new Accurate SEE algorithm in Move Ordering to order good captures as they were but order bad captures before or after the killer move, relying on MvvLva to figure out how bad they are. This can improve the normal search's capture selection as well.  

### 👏 Acknowledgements
- **[Jay Honnold](https://github.com/jhonnold)**: Usage of SEE in Move Ordering in such a fashion was suggested by Jay. Thank you for the contribution, Jay. 🙌

### 📈 ELO
**[STC](http://tests.findingchess.com/test/1035/)**:
```
ELO   | 23.11 +- 10.40 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 2304 W: 694 L: 541 D: 1069
```
**[LTC](http://tests.findingchess.com/test/1037/)**:
```
ELO   | 11.41 +- 6.71 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4904 W: 1249 L: 1088 D: 2567
```