### PR TITLE
🦈 IMP: Simplify Transposition Table Lookup

### DIFF
--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -277,21 +277,9 @@ namespace StockDory
                     ttMove = storedEntry.Move;
 
                     if (!Pv && storedEntry.Depth >= depth) {
-                        switch (storedEntry.Type) {
-                            case Exact:
-                                TTNodes++;
-                                return storedEntry.Evaluation;
-                            case BetaCutoff:
-                                alpha = std::max(alpha, storedEntry.Evaluation);
-                                break;
-                            case AlphaUnchanged:
-                                beta  = std::min(beta , storedEntry.Evaluation);
-                                break;
-                            case Invalid:
-                                break;
-                        }
-
-                        if (alpha >= beta) {
+                        if (storedEntry.Type == Exact          ||
+                           (storedEntry.Type == BetaCutoff     && storedEntry.Evaluation >= beta ) ||
+                           (storedEntry.Type == AlphaUnchanged && storedEntry.Evaluation <= alpha)) {
                             TTNodes++;
                             return storedEntry.Evaluation;
                         }


### PR DESCRIPTION
### 🎯 Summary

This PR simplifies the Transposition Table Lookup in StockDory's Search, allowing for the same operation to be done in fewer lines of code.

### 👏 Acknowledgements
- **[Rak Laptudirm](https://github.com/raklaptudirm)**: This simplification was suggested by Rak quite a while ago. Much appreciated! 🙌

### 📈 ELO
**[STC](http://tests.findingchess.com/test/1152/)**:
```
ELO   | 1.35 +- 2.92 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 28408 W: 7477 L: 7367 D: 13564
```
**[LTC](http://tests.findingchess.com/test/1153/)**:
```
ELO   | 1.40 +- 2.84 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=256MB
LLR   | 2.98 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 27784 W: 6801 L: 6689 D: 14294
```