### PR TITLE
initializing_constexp_variables

### DIFF
--- a/src/Engine/Time/TimeManager.h
+++ b/src/Engine/Time/TimeManager.h
@@ -8,7 +8,8 @@
 
 #include "../Move/OrderedMoveList.h"
 #include "TimeControl.h"
-
+#include "../Move/KillerTable.h"
+#include "../Move/HistoryTable.h"
 #include "../../Backend/Board.h"
 
 namespace StockDory
@@ -37,8 +38,8 @@ namespace StockDory
 
             constexpr static uint64_t MoveInstantTime      = 500;
 
-            constexpr static KillerTable  DummyKTable;
-            constexpr static HistoryTable DummyHTable;
+            constexpr static KillerTable  DummyKTable = KillerTable();
+            constexpr static HistoryTable DummyHTable = HistoryTable();
 
         public:
             static TimeControl Default()


### PR DESCRIPTION
Hi,


I opened an issue a couple days ago about a compiling error persisting about two constexp variables not instantiated in file "src/Engine/Time/TimeManager.h". 