### PR TITLE
🦈 IMP: Granular Late Move Reduction/Extension Calculation

### DIFF
--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -61,7 +61,7 @@ namespace StockDory
     inline auto LMRTable =
     [] -> Array<int32_t, MaxDepth, MaxMove>
     {
-        const auto formula = [](const uint8_t depth, const uint8_t move) -> int16_t
+        const auto formula = [](const uint8_t depth, const uint8_t move) -> int32_t
         {
             return static_cast<int32_t>((std::log(depth) * std::log(move) / 2 - 0.2) * 1024);
         };

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -58,7 +58,7 @@ namespace StockDory
 
     inline TranspositionTable<SearchTranspositionEntry> TT (16 * MB);
 
-    constexpr  uint16_t LMRGranularityFactor = 1024;
+    constexpr uint16_t LMRGranularityFactor = 1024;
 
     inline auto LMRTable =
     [] -> Array<int32_t, MaxDepth, MaxMove>

--- a/src/Engine/TunableParameter.h
+++ b/src/Engine/TunableParameter.h
@@ -17,7 +17,7 @@ namespace StockDory
     constexpr uint8_t TimeIncrementPartitionDenominator = 4;
     constexpr uint8_t TimeProcessingOverhead            = 10;
 
-    constexpr Array<uint16_t, 5> SearchStabilityTimeOptimizationFactor{
+    constexpr Array<uint16_t, 5> SearchStabilityTimeOptimizationFactor {
         250, 180, 120, 99, 97
     };
 

--- a/src/Engine/TunableParameter.h
+++ b/src/Engine/TunableParameter.h
@@ -46,8 +46,11 @@ namespace StockDory
     constexpr uint8_t LMPMaximumDepth  = 3;
     constexpr uint8_t LMPLastQuietBase = 3;
 
-    constexpr uint8_t LMRMinimumDepth = 3;
-    constexpr uint8_t LMRMinimumMoves = 3;
+    constexpr  uint8_t LMRMinimumDepth      =    3;
+    constexpr  uint8_t LMRMinimumMoves      =    3;
+    constexpr uint16_t LMRNotPVBonus        = 1024;
+    constexpr uint16_t LMRNotImprovingBonus = 1024;
+    constexpr uint16_t LMRGaveCheckPenalty  = 1024;
 
     constexpr uint8_t FutilityDepthFactor = 150;
 


### PR DESCRIPTION
### 🎯 Summary

This PR enables a more granular calculation of late move reduction or extension, intending to fine-tune each reduction bonus or penalty.

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://verdict.shaheryarsohail.com/test/183/)**:
```
Elo   | 0.34 +- 1.66 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 56012 W: 14052 L: 13997 D: 27963
Penta | [630, 6673, 13421, 6576, 706]
```