### PR TITLE
🦈 IMP: History Heuristic in Late Move Reduction/Extension

### DIFF
--- a/src/Engine/NetworkArchitecture.h
+++ b/src/Engine/NetworkArchitecture.h
@@ -12,8 +12,14 @@
 // Activation Function:
 constexpr auto ClippedReLU = &MantaRay::ClippedReLU<MantaRay::i16, 0, 255>::Activate;
 
+constexpr size_t AccumulatorStackSize = StockDory::MaxDepth * 4;
+
 // Architecture:
-using Starshard = MantaRay::Perspective<MantaRay::i16, MantaRay::i32, ClippedReLU, 768, 256, 1, 512, 400, 255, 64>;
-using Aurora    = MantaRay::Perspective<MantaRay::i16, MantaRay::i32, ClippedReLU, 768, 384, 1, 512, 400, 255, 64>;
+using Starshard = MantaRay::Perspective<
+    MantaRay::i16, MantaRay::i32, ClippedReLU, 768, 256, 1, AccumulatorStackSize, 400, 255, 64
+>;
+using Aurora    = MantaRay::Perspective<
+    MantaRay::i16, MantaRay::i32, ClippedReLU, 768, 384, 1, AccumulatorStackSize, 400, 255, 64
+>;
 
 #endif //STOCKDORY_NETWORKARCHITECTURE_H

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -963,7 +963,7 @@ namespace StockDory
 
                         evaluation = -PVS<OColor, false, false>(
                             ply + 1,
-                            std::clamp<int16_t>(depth - r, 1, depth + 1),
+                            std::clamp<int16_t>(depth - r, 1, depth),
                             -alpha - 1,
                             -alpha
                         );

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -962,7 +962,7 @@ namespace StockDory
 
                         evaluation = -PVS<OColor, false, false>(
                             ply + 1,
-                            std::clamp<int16_t>(depth - r, 1, depth + 1),
+                            std::clamp<int16_t>(depth - r, 1, depth),
                             -alpha - 1,
                             -alpha
                         );

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -921,14 +921,16 @@ namespace StockDory
                     // shows potential to improve our position, we will research with a full window search assuming
                     // we are in a PV branch
 
-                    // Late Move Reduction (LMR):
+                    // Late Move Reduction and Extension (LMR-E):
                     //
-                    // LMR is a reduction technique that allows us to reduce the depth of the search for moves that
+                    // Base LMR is a reduction technique that allows us to reduce the depth of the search for moves that
                     // appear later since, according to the move policy, they are likely worse than the moves that were
-                    // searched earlier. The moves that appear later are searched with a reduced depth, and if they give
-                    // promising evaluation (i.e., greater than our current lower bound, which is alpha), we research
-                    // them at a full depth. The researches are relatively inexpensive due to the transposition table,
-                    // and the time we save by not searching moves that are unlikely to improve our position is worth it
+                    // searched earlier. However, LMR-E allows us to extend the search depth for moves that may be very
+                    // tactically promising or likely to fail high (i.e., produce a beta cut-off). If the reduced or
+                    // extended search gives a promising evaluation (i.e., greater than our current lower bound, which
+                    // is alpha), we then research them at a full depth. The researches are relatively inexpensive due
+                    // to the transposition table, and the time we save by not searching moves that are unlikely to
+                    // improve our position is worth it
                     if (doLMR && i > LMRMinimumMoves) {
                         // Reduction values are determined by a formula that takes into account the current depth and
                         // move number. Current formula:
@@ -946,7 +948,8 @@ namespace StockDory
                         // the move may be tactical and in certain cases, extend the search depth instead
                         if (Board.Checked<OColor>()) r--;
 
-                        // Increase reduction for bad history moves and reduce for good history moves
+                        // Increase reduction for bad history moves and reduce for good history moves (possibly
+                        // extending the search depth)
                         r -= History[Color][movingPiece][move.To()] / (HistoryLimit / 2);
 
                         evaluation = -PVS<OColor, false, false>(

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -954,7 +954,8 @@ namespace StockDory
 
                         // Increase reduction for bad history moves and reduce for good history moves (possibly
                         // extending the search depth)
-                        r -= History[Color][movingPiece][move.To()];
+                        const int16_t history = History[Color][movingPiece][move.To()];
+                        r -= history / ((HistoryLimit / LMRHistoryPartition) / LMRHistoryWeight);
 
                         // Divide by the granularity factor to ensure that the fixed-point reduction is correctly
                         // mapped to discrete reduction
@@ -962,7 +963,7 @@ namespace StockDory
 
                         evaluation = -PVS<OColor, false, false>(
                             ply + 1,
-                            std::clamp<int16_t>(depth - r, 1, depth),
+                            std::clamp<int16_t>(depth - r, 1, depth + 1),
                             -alpha - 1,
                             -alpha
                         );

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -855,7 +855,11 @@ namespace StockDory
             uint8_t quietMoves = 0;
             for (uint8_t i = 0; i < moves.Count(); i++) {
                 const Move move  = moves[i];
-                const bool quiet = Board[move.To()].Piece() == NAP;
+
+                const Piece movingPiece = Board[move.From()].Piece();
+                const Piece targetPiece = Board[move.  To()].Piece();
+
+                const bool quiet = targetPiece == NAP;
 
                 quietMoves += quiet;
 
@@ -942,9 +946,12 @@ namespace StockDory
                         // the move may be tactical and in certain cases, extend the search depth instead
                         if (Board.Checked<OColor>()) r--;
 
+                        // Increase reduction for bad history moves and reduce for good history moves
+                        r -= History[Color][movingPiece][move.To()] / (HistoryLimit / 2);
+
                         evaluation = -PVS<OColor, false, false>(
                             ply + 1,
-                            std::max<int16_t>(depth - r, 1),
+                            std::clamp<int16_t>(depth - r, 1, depth + 1),
                             -alpha - 1,
                             -alpha
                         );

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -952,13 +952,13 @@ namespace StockDory
                         // the move may be tactical and in certain cases, extend the search depth instead
                         if (Board.Checked<OColor>()) r -= LMRGaveCheckPenalty;
 
+                        // Increase reduction for bad history moves and reduce for good history moves (possibly
+                        // extending the search depth)
+                        r -= History[Color][movingPiece][move.To()];
+
                         // Divide by the granularity factor to ensure that the fixed-point reduction is correctly
                         // mapped to discrete reduction
                         r /= LMRGranularityFactor;
-
-                        // Increase reduction for bad history moves and reduce for good history moves (possibly
-                        // extending the search depth)
-                        r -= History[Color][movingPiece][move.To()] / (HistoryLimit / 2);
 
                         evaluation = -PVS<OColor, false, false>(
                             ply + 1,

--- a/src/Engine/TunableParameter.h
+++ b/src/Engine/TunableParameter.h
@@ -51,6 +51,8 @@ namespace StockDory
     constexpr uint16_t LMRNotPVBonus        = 1024;
     constexpr uint16_t LMRNotImprovingBonus = 1024;
     constexpr uint16_t LMRGaveCheckPenalty  = 1024;
+    constexpr uint16_t LMRHistoryWeight     = 1024;
+    constexpr uint16_t LMRHistoryPartition  =    2;
 
     constexpr uint8_t FutilityDepthFactor = 150;
 


### PR DESCRIPTION
### 🎯 Summary

This PR aims to incorporate the usage of History Heuristic to decide which moves to reduce and which moves to reduce less (on occasion, extend). Moves with a bad history are reduced more, and moves with good history scores are reduced less (occasionally extended).

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://verdict.shaheryarsohail.com/test/214/)**:
```
Elo   | 8.78 +- 5.30 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5820 W: 1530 L: 1383 D: 2907
Penta | [72, 654, 1321, 781, 82]
```
**[LTC](http://verdict.shaheryarsohail.com/test/215/)**:
```
Elo   | 9.89 +- 5.43 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4426 W: 1081 L: 955 D: 2390
Penta | [14, 494, 1081, 600, 24]
```