### PR TITLE
🦈 IMP: Reduce Late Moves Search Depth Further Given Transposition Table Move Branch

### DIFF
--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -945,6 +945,10 @@ namespace StockDory
                         // If we are not in a PV branch, we can afford to reduce the search depth further
                         if (!PV) r += LMRNotPVBonus;
 
+                        // Increase the reduction for moves if we have a transposition table move since it's most likely
+                        // the best move in the position and the others are likely worse
+                        if (ttHit && ttEntry.Type != Alpha) r += LMRTTMoveBonus;
+
                         // If we are not improving positionally, we can afford to reduce the search depth further
                         if (!improving) r += LMRNotImprovingBonus;
 

--- a/src/Engine/TunableParameter.h
+++ b/src/Engine/TunableParameter.h
@@ -49,6 +49,7 @@ namespace StockDory
     constexpr  uint8_t LMRMinimumDepth      =    3;
     constexpr  uint8_t LMRMinimumMoves      =    3;
     constexpr uint16_t LMRNotPVBonus        = 1024;
+    constexpr uint16_t LMRTTMoveBonus       = 1024;
     constexpr uint16_t LMRNotImprovingBonus = 1024;
     constexpr uint16_t LMRGaveCheckPenalty  = 1024;
     constexpr uint16_t LMRHistoryWeight     = 1024;


### PR DESCRIPTION
### 🎯 Summary

This PR implements another reduction in LMR-E for when the position has a transposition table move available. Transposition table moves typically come from previous searches, and while they may originate from a lower-depth search, they were the best move and will likely remain the best move even at a higher depth. All other moves found later in the move list are likely worse, so we can reduce the depth at which we search them.

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://verdict.shaheryarsohail.com/test/225/)**:
```
Elo   | 5.37 +- 3.83 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10418 W: 2604 L: 2443 D: 5371
Penta | [99, 1216, 2438, 1337, 119]
```
**[LTC](http://verdict.shaheryarsohail.com/test/227/)**:
```
Elo   | 5.77 +- 3.93 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8550 W: 2029 L: 1887 D: 4634
Penta | [37, 984, 2104, 1100, 50]
```