### PR TITLE
🦈 IMP: Material Scaled Neural Network Evaluation

### DIFF
--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -63,9 +63,9 @@ namespace StockDory
     {
         const auto formula = [](const uint8_t depth, const uint8_t move) -> int32_t
         {
-            const int32_t value = (std::log(depth) * std::log(move) / 2 - 0.2) * LMRGranularityFactor;
+            const int32_t value = (std::log(depth) * std::log(move) / 2 - 0.2) * LMRQuantization;
 
-            return value / LMRGranularityFactor > 0 ? value : 0;
+            return value / LMRQuantization > 0 ? value : 0;
         };
 
         Array<int32_t, MaxDepth, MaxMove> temp {};
@@ -961,7 +961,7 @@ namespace StockDory
 
                         // Divide by the granularity factor to ensure that the fixed-point reduction is correctly
                         // mapped to discrete reduction
-                        r /= LMRGranularityFactor;
+                        r /= LMRQuantization;
 
                         evaluation = -PVS<OColor, false, false>(
                             ply + 1,
@@ -1181,9 +1181,9 @@ namespace StockDory
                                         Count(rook  ) * MaterialScalingWeightRook   +
                                         Count(queen ) * MaterialScalingWeightQueen  ;
 
-            weightedMaterial += MaterialScalingGranularity - MaterialScalingWeightedStartValue;
+            weightedMaterial += MaterialScalingQuantization - MaterialScalingWeightedStartValue;
 
-            return (Evaluation::Evaluate(Color, ThreadId) * weightedMaterial) / MaterialScalingGranularity;
+            return (Evaluation::Evaluate(Color, ThreadId) * weightedMaterial) / MaterialScalingQuantization;
         }
 
         static void TryWriteTT(SearchTranspositionEntry& pEntry, const SearchTranspositionEntry nEntry)

--- a/src/Engine/TunableParameter.h
+++ b/src/Engine/TunableParameter.h
@@ -46,7 +46,7 @@ namespace StockDory
     constexpr uint8_t LMPMaximumDepth  = 3;
     constexpr uint8_t LMPLastQuietBase = 3;
 
-    constexpr uint16_t LMRGranularityFactor = 1024;
+    constexpr uint16_t LMRQuantization      = 1024;
     constexpr  uint8_t LMRMinimumDepth      =    3;
     constexpr  uint8_t LMRMinimumMoves      =    3;
     constexpr uint16_t LMRNotPVBonus        = 1024;
@@ -62,7 +62,7 @@ namespace StockDory
     constexpr uint16_t HistoryShiftDown  = 250;
 
     constexpr uint16_t MaterialScalingWeightedStartValue =  6688;
-    constexpr uint16_t MaterialScalingGranularity        = 16384;
+    constexpr uint16_t MaterialScalingQuantization       = 16384;
     constexpr uint16_t MaterialScalingWeightPawn         =     0;
     constexpr uint16_t MaterialScalingWeightKnight       =   308;
     constexpr uint16_t MaterialScalingWeightBishop       =   346;

--- a/src/Engine/TunableParameter.h
+++ b/src/Engine/TunableParameter.h
@@ -46,6 +46,7 @@ namespace StockDory
     constexpr uint8_t LMPMaximumDepth  = 3;
     constexpr uint8_t LMPLastQuietBase = 3;
 
+    constexpr uint16_t LMRGranularityFactor = 1024;
     constexpr  uint8_t LMRMinimumDepth      =    3;
     constexpr  uint8_t LMRMinimumMoves      =    3;
     constexpr uint16_t LMRNotPVBonus        = 1024;
@@ -59,6 +60,14 @@ namespace StockDory
 
     constexpr uint16_t HistoryMultiplier = 300;
     constexpr uint16_t HistoryShiftDown  = 250;
+
+    constexpr uint16_t MaterialScalingWeightedStartValue =  6688;
+    constexpr uint16_t MaterialScalingGranularity        = 16384;
+    constexpr uint16_t MaterialScalingWeightPawn         =     0;
+    constexpr uint16_t MaterialScalingWeightKnight       =   308;
+    constexpr uint16_t MaterialScalingWeightBishop       =   346;
+    constexpr uint16_t MaterialScalingWeightRook         =   521;
+    constexpr uint16_t MaterialScalingWeightQueen        =   994;
 
     constexpr uint8_t TTReplacementDepthMargin = 3;
 


### PR DESCRIPTION
### 🎯 Summary

This PR scales the neural network evaluation towards preserving material. Doing so, it avoids making exchanges unless they're better for it by a long shot. Inadvertently, this change avoids pawn endgames, and if such an endgame is still reached, it then values the promotion of pawns. 

### 👏 Acknowledgements
- **[Jonathan Hallström](https://github.com/JonathanHallstrom)**: The material scaling implementation is based on the implementation in Jonathan's [Pawnocchio](https://github.com/JonathanHallstrom/pawnocchio) engine.

### 📈 ELO
### Single-threaded
**[STC](http://verdict.shaheryarsohail.com/test/339/)**:
```
Elo   | 2.63 +- 2.10 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 34750 W: 8604 L: 8341 D: 17805
Penta | [419, 4043, 8083, 4516, 314]
```
**[LTC](http://verdict.shaheryarsohail.com/test/342/)**:
```
Elo   | 10.38 +- 5.47 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4050 W: 984 L: 863 D: 2203
Penta | [13, 415, 1052, 528, 17]
```

### 2 Threads
**[LTC](http://verdict.shaheryarsohail.com/test/347/)**:
```
Elo   | 10.33 +- 5.52 (95%)
SPRT  | 60.0+0.60s Threads=2 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4138 W: 975 L: 852 D: 2311
Penta | [14, 446, 1027, 567, 15]
```