### PR TITLE
🦈 IMP: Better Handle Extreme Evaluations in Transposition Table

### DIFF
--- a/src/Engine/Common.h
+++ b/src/Engine/Common.h
@@ -16,14 +16,16 @@ namespace StockDory
 
     using Score = int32_t;
 
-    constexpr Score Infinity = 1000000     ;
-    constexpr Score Mate     = Infinity - 1;
-    constexpr Score Draw     = 0           ;
+    constexpr Score Mate = 31000;
+    constexpr Score Draw =     0;
 
-    constexpr Score None     = Infinity + 1;
+    constexpr Score Infinity = Mate + 1;
+    constexpr Score     None = Mate + 2;
 
     constexpr uint8_t MaxDepth = 128;
     constexpr uint8_t MaxMove  = 218;
+
+    constexpr Score MateInMaxDepth = Mate - MaxDepth * 4;
 
     constexpr uint16_t HistoryLimit = 16384;
 
@@ -34,6 +36,14 @@ namespace StockDory
 
     using KTable = Array<Move, 2, MaxDepth>;
     using HTable = Array<int16_t, 2, 6, 64>;
+
+    bool IsMate(const Score score) { return abs(score) >= MateInMaxDepth; }
+
+    bool IsWin (const Score score) { return score >=  MateInMaxDepth; }
+    bool IsLoss(const Score score) { return score <= -MateInMaxDepth; }
+
+    Score  WinIn(const uint8_t ply) { return  Mate - ply; }
+    Score LossIn(const uint8_t ply) { return -Mate + ply; }
 
 } // StockDory
 

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -1170,6 +1170,8 @@ namespace StockDory
 
         static void TryWriteTT(SearchTranspositionEntry& pEntry, const SearchTranspositionEntry nEntry)
         {
+            if (abs(nEntry.Evaluation) >= CompressedInfinity) return;
+
             if (nEntry.Type == Exact || nEntry.Hash != pEntry.Hash ||
                (pEntry.Type == Alpha &&
                 nEntry.Type == Beta) ||


### PR DESCRIPTION
### 🎯 Summary

This PR corrects the stored evaluation in the transposition table when storing mate evaluations. Previously, they may get clamped, leading to multiple threads being confused in finding the correct shortest mate.

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://verdict.shaheryarsohail.com/test/306/)**:
```
Elo   | 0.26 +- 1.56 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 61706 W: 14959 L: 14913 D: 31834
Penta | [631, 7495, 14564, 7523, 640]
```
**[LTC](http://verdict.shaheryarsohail.com/test/321/)**:
```
Elo   | 0.27 +- 1.48 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 59028 W: 13326 L: 13280 D: 32422
Penta | [300, 6979, 14882, 7081, 272]
```