### PR TITLE
🦈 IMP: Avoid Duplicating Neural Network Weights and Biases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ include(${CPM_DOWNLOAD_LOCATION})
 CPMAddPackage(
         NAME MantaRay
         GITHUB_REPOSITORY TheBlackPlague/MantaRay
-        GIT_TAG 1c547d179c7cdf4f24e4f8a1fea228c6178d0ae2
+        GIT_TAG ddc063e1fa688ca3bc9de793e4d5a6813d901289
         OPTIONS
         "BUILD_TEST OFF"
         "BUILD_MB OFF"

--- a/src/Engine/Evaluation.h
+++ b/src/Engine/Evaluation.h
@@ -37,7 +37,7 @@ namespace StockDory
 
         static void Initialize()
         {
-            const size_t threadCount = ThreadPool.Size() + 1;
+            const size_t threadCount = ThreadPool.Size();
 
             ThreadLocalStack.clear();
             ThreadLocalStack.reserve(threadCount);

--- a/src/Engine/Evaluation.h
+++ b/src/Engine/Evaluation.h
@@ -21,7 +21,13 @@ namespace StockDory
     class Evaluation
     {
 
-        static inline std::vector<Aurora> NNs;
+        static inline Aurora NN = [] -> Aurora
+        {
+            MantaRay::BinaryMemoryStream stream (_NeuralNetworkBinaryData, sizeof _NeuralNetworkBinaryData);
+            return Aurora(stream);
+        }();
+
+        static inline std::vector<AuroraStack> ThreadLocalStack;
 
         public:
         static std::string Name()
@@ -33,56 +39,68 @@ namespace StockDory
         {
             const size_t threadCount = ThreadPool.Size() + 1;
 
-            NNs.clear();
-            NNs.reserve(threadCount);
+            ThreadLocalStack.clear();
+            ThreadLocalStack.reserve(threadCount);
 
             for (size_t i = 0; i < threadCount; i++) {
-                MantaRay::BinaryMemoryStream stream (_NeuralNetworkBinaryData, sizeof _NeuralNetworkBinaryData);
-                NNs.emplace_back(stream);
+                ThreadLocalStack.emplace_back();
+                NN.Refresh(*ThreadLocalStack[i]);
             }
         }
 
         static void ResetNetworkState(const size_t threadId = 0)
         {
-            NNs[threadId].Reset();
-            NNs[threadId].Refresh();
+            AuroraStack& stack = ThreadLocalStack[threadId];
+
+            stack.Reset();
+            NN.Refresh(*stack);
         }
 
         [[clang::always_inline]]
         static void PreMove(const size_t threadId = 0)
         {
-            NNs[threadId].Push();
+            AuroraStack& stack = ThreadLocalStack[threadId];
+            stack++;
         }
 
         [[clang::always_inline]]
         static void PreUndoMove(const size_t threadId = 0)
         {
-            NNs[threadId].Pop();
+            AuroraStack& stack = ThreadLocalStack[threadId];
+            stack--;
         }
 
         [[clang::always_inline]]
         static void Activate(const Piece piece, const Color color, const Square sq, const size_t threadId = 0)
         {
-            NNs[threadId].Insert(piece, color, sq);
+            AuroraStack& stack = ThreadLocalStack[threadId];
+
+            NN.Insert(piece, color, sq, *stack);
         }
 
         [[clang::always_inline]]
         static void Deactivate(const Piece piece, const Color color, const Square sq, const size_t threadId = 0)
         {
-            NNs[threadId].Remove(piece, color, sq);
+            AuroraStack& stack = ThreadLocalStack[threadId];
+
+            NN.Remove(piece, color, sq, *stack);
         }
 
         [[clang::always_inline]]
         static void Transition(const Piece piece, const Color color, const Square from, const Square to,
                                const size_t threadId = 0)
         {
-            NNs[threadId].Move(piece, color, from, to);
+            AuroraStack& stack = ThreadLocalStack[threadId];
+
+            NN.Move(piece, color, from, to, *stack);
         }
 
         [[clang::always_inline]]
         static Score Evaluate(const Color color, const size_t threadId = 0)
         {
-            return NNs[threadId].Evaluate(color);
+            AuroraStack& stack = ThreadLocalStack[threadId];
+
+            return NN.Evaluate(color, *stack);
         }
 
     };

--- a/src/Engine/NetworkArchitecture.h
+++ b/src/Engine/NetworkArchitecture.h
@@ -8,18 +8,23 @@
 
 #include <MantaRay/Backend/Kernel/Activation/ClippedReLU.h>
 #include <MantaRay/Frontend/Architecture/Perspective.h>
+#include <MantaRay/Frontend/Architecture/Common/AccumulatorStack.h>
 
 // Activation Function:
 constexpr auto ClippedReLU = &MantaRay::ClippedReLU<MantaRay::i16, 0, 255>::Activate;
 
-constexpr size_t AccumulatorStackSize = StockDory::MaxDepth * 4;
-
 // Architecture:
 using Starshard = MantaRay::Perspective<
-    MantaRay::i16, MantaRay::i32, ClippedReLU, 768, 256, 1, AccumulatorStackSize, 400, 255, 64
+    MantaRay::i16, MantaRay::i32, ClippedReLU, 768, 256, 1, 400, 255, 64
 >;
 using Aurora    = MantaRay::Perspective<
-    MantaRay::i16, MantaRay::i32, ClippedReLU, 768, 384, 1, AccumulatorStackSize, 400, 255, 64
+    MantaRay::i16, MantaRay::i32, ClippedReLU, 768, 384, 1, 400, 255, 64
 >;
+
+// Accumulator Stack:
+constexpr size_t AccumulatorStackSize = StockDory::MaxDepth * 4;
+
+using StarshardStack = MantaRay::AccumulatorStack<MantaRay::i16, 256, AccumulatorStackSize>;
+using    AuroraStack = MantaRay::AccumulatorStack<MantaRay::i16, 384, AccumulatorStackSize>;
 
 #endif //STOCKDORY_NETWORKARCHITECTURE_H


### PR DESCRIPTION
### 🎯 Summary

This PR allows avoiding the duplication of neural network weights and biases for every thread. According to the change, all threads will share the neural network weights and biases, while only the accumulator stack is local to each thread.

### 👏 Acknowledgements
NA

### 📈 ELO
NA