### PR TITLE
⚒️ FIX: Search Task Alignment Preventing False Sharing

### DIFF
--- a/src/Engine/Common.h
+++ b/src/Engine/Common.h
@@ -31,6 +31,8 @@ namespace StockDory
 
     constexpr size_t MB = 1024 * 1024;
 
+    constexpr size_t CacheLineSize = 64;
+
     using MS = std::chrono::milliseconds;
     using TP = std::chrono::time_point<std::chrono::steady_clock>;
 

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -309,7 +309,7 @@ namespace StockDory
     };
 
     template<SearchThreadType ThreadType = Main, class EventHandler = DefaultSearchEventHandler>
-    class SearchTask
+    class alignas(CacheLineSize) SearchTask
     {
 
         Board Board {};


### PR DESCRIPTION
### 🎯 Summary

This PR addresses a cache line misalignment issue in the Parallel Task Pool that degrades SMP performance when more than two threads are used (i.e., when multiple tasks exist in the pool). Due to improper alignment on cache line boundaries, a thread’s node counter may reside on the same cache line as another thread’s board data. This causes false sharing, as both threads frequently write to the same cache line, resulting in excessive cache coherence traffic and reduced performance. This PR aligns all tasks to cache-line boundaries (padding where necessary) to ensure that cache coherence traffic only occurs in the transposition table.

### 👏 Acknowledgements
- **[Andrew Grant](https://github.com/AndyGrant)**: After discussing this issue with Andrew, he suggested that false sharing could be the culprit, as it aligns with the symptoms. Fortunately, he remained adamant in supporting that suggestion, prompting a more detailed analysis that led to the performance degradation being fixed. Thanks Andrew! 🙌

### 📈 ELO
Due to the nature of this PR, only SMP tests where thread counts exceed two threads (i.e., four threads) were done. It's fairly apparent that this won't cause a regression in single-threaded or double-threaded performance, but may have a more positive impact as the thread count increases.

### 4 Threads
**[STC](http://verdict.shaheryarsohail.com/test/529/)**:
```
Elo   | 16.70 +- 7.48 (95%)
SPRT  | 10.0+0.10s Threads=4 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2686 W: 716 L: 587 D: 1383
Penta | [22, 274, 633, 381, 33]
```
**[LTC](http://verdict.shaheryarsohail.com/test/530/)**:
```
Elo   | 7.66 +- 4.64 (95%)
SPRT  | 60.0+0.60s Threads=4 Hash=512MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5854 W: 1362 L: 1233 D: 3259
Penta | [15, 660, 1461, 763, 28]
```