### PR TITLE
🦈 IMP: IIR Before Risky Pruning

### DIFF
--- a/src/Backend/Type/Move.h
+++ b/src/Backend/Type/Move.h
@@ -86,6 +86,9 @@ struct Move
         return Internal == other.Internal;
     }
 
+    // ReSharper disable once CppNonExplicitConversionOperator
+    constexpr operator bool() const { return Internal != 0; }
+
     [[nodiscard]]
     std::string ToString() const
     {

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -659,6 +659,13 @@ namespace StockDory
                 }
             }
 
+            // Internal Iterative Reduction (IIR):
+            //
+            // If we are at a high enough depth but there is no valid transposition table move, we can reduce the search
+            // depth by a small amount to speed up the search
+            if (depth >= IIRMinimumDepth && !ttMove)
+                depth -= IIRDepthReduction;
+
             Score staticEvaluation;
             bool  improving       ;
 
@@ -829,13 +836,6 @@ namespace StockDory
 
             // We continue from here if we are in check
             Checked:
-
-            // Internal Iterative Reduction (IIR):
-            //
-            // If we are at a high enough depth but have no transposition table entry, we can reduce the depth of the
-            // search by a small amount - good positions are normally reached by a lot of different sequences and
-            // usually have a transposition table entry
-            if (depth >= IIRMinimumDepth && !ttHit) depth -= IIRDepthReduction;
 
             using MoveList = OrderedMoveList<Color>;
 


### PR DESCRIPTION
### 🎯 Summary

This PR aims at correcting the logic for Internal Iterative Reductions (IIR) by making it occur before risky pruning (so they are also done with a reduced depth, should it be applicable). Furthermore, it refines the logic by using a move check instead of checking for an entry hit.

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://verdict.shaheryarsohail.com/test/538/)**:
```
Elo   | 2.92 +- 2.35 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 28666 W: 7191 L: 6950 D: 14525
Penta | [352, 3395, 6581, 3670, 335]
```
**[LTC](http://verdict.shaheryarsohail.com/test/539/)**:
```
Elo   | 9.97 +- 5.45 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 4392 W: 1048 L: 922 D: 2422
Penta | [18, 481, 1075, 601, 21]
```