### PR TITLE
🦈 IMP: Avoid Entering Quiescence Search Under Check

### DIFF
--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -563,11 +563,13 @@ namespace StockDory
                 if (PV) SelectiveDepth = std::max(SelectiveDepth, ply);
             }
 
+            const bool checked = Board.Checked<Color>();
+
             // If we've exhausted our search depth, we should check if there are any tactical sequences available
             // over the horizon. In the case there are, our evaluation at this point is not truly accurate, and we must
             // get a more accurate evaluation by stepping through to the end of the tactical sequence - this is handled
             // by the Quiescence search
-            if (depth <= 0) return Quiescence<Color, PV>(ply, alpha, beta);
+            if (depth <= 0 && !checked) return Quiescence<Color, PV>(ply, alpha, beta);
 
             const ZobristHash hash = Board.Zobrist();
 
@@ -661,8 +663,6 @@ namespace StockDory
 
             Score staticEvaluation;
             bool  improving       ;
-
-            const bool checked = Board.Checked<Color>();
 
             if (checked) {
                 // Last non-checked Static Evaluation:

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -565,10 +565,10 @@ namespace StockDory
 
             const bool checked = Board.Checked<Color>();
 
-            // If we've exhausted our search depth, we should check if there are any tactical sequences available
-            // over the horizon. In the case there are, our evaluation at this point is not truly accurate, and we must
-            // get a more accurate evaluation by stepping through to the end of the tactical sequence - this is handled
-            // by the Quiescence search
+            // If we've exhausted our search depth and aren't in check, we should check if there are any tactical
+            // sequences just over the horizon. If there are, we should get a more accurate evaluation through a
+            // Quiescence search. If we are in check, we should go down the normal search path, extending as needed to
+            // ensure we find a suitable evasion
             if (depth <= 0 && !checked) return Quiescence<Color, PV>(ply, alpha, beta);
 
             const ZobristHash hash = Board.Zobrist();


### PR DESCRIPTION
### 🎯 Summary

This PR aims to prevent the engine from entering Quiescence Search when under check, as it can result in only tactical evasions being observed. Furthermore, it avoids a proper check extension to give better resolution.

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://verdict.shaheryarsohail.com/test/540/)**:
```
Elo   | 2.88 +- 2.31 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
Games | N: 29344 W: 7246 L: 7003 D: 15095
Penta | [323, 3490, 6836, 3667, 356]
```
**[LTC](http://verdict.shaheryarsohail.com/test/541/)**:
```
Elo   | 2.90 +- 2.33 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 24554 W: 5504 L: 5299 D: 13751
Penta | [134, 2881, 6046, 3078, 138]
```