### PR TITLE
⚒️ FIX: Correct LMR Bonus Logic for Valid TT Move

### DIFF
--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -951,7 +951,7 @@ namespace StockDory
 
                         // Increase the reduction for moves if we have a transposition table move since it's most likely
                         // the best move in the position and the others are likely worse
-                        if (ttHit && ttEntry.Type != Alpha) r += LMRTTMoveBonus;
+                        if (ttMove) r += LMRTTMoveBonus;
 
                         // If we are not improving positionally, we can afford to reduce the search depth further
                         if (!improving) r += LMRNotImprovingBonus;


### PR DESCRIPTION
### 🎯 Summary

This PR corrects the logic for the reduction bonus given in LMR for a valid transposition table move.

### 👏 Acknowledgements
NA

### 📈 ELO
**[STC](http://verdict.shaheryarsohail.com/test/546/)**:
```
Elo   | 5.49 +- 4.28 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 8606 W: 2250 L: 2114 D: 4242
Penta | [96, 1002, 1977, 1126, 102]
```
**[LTC](http://verdict.shaheryarsohail.com/test/548/)**:
```
Elo   | 1.43 +- 2.32 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.97 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 24234 W: 5509 L: 5409 D: 13316
Penta | [116, 2885, 6027, 2961, 128]
```
**[VLTC](http://verdict.shaheryarsohail.com/test/560/)**:
```
Elo   | 3.30 +- 3.21 (95%)
SPRT  | 120.0+1.20s Threads=1 Hash=256MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 12100 W: 2709 L: 2594 D: 6797
Penta | [37, 1405, 3064, 1494, 50]
```