### PR TITLE
⚒️ FIX: Prevent Premature SMP Helper Thread Termination

### DIFF
--- a/.github/workflows/executable.yml
+++ b/.github/workflows/executable.yml
@@ -74,7 +74,7 @@ jobs:
     - if: matrix.os == 'windows-latest'
       name: Install Clang 20 (Windows)
       run: |
-        choco install llvm --version 20.1.7 -y
+        choco install llvm --version 20.1.7 --force -y
     - if: matrix.os == 'macos-latest'
       name: Install Clang 20 (MacOS)
       run: |

--- a/.idea/StockDory.iml
+++ b/.idea/StockDory.iml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<module classpath="CMake" type="CPP_MODULE" version="4" />
+<module classpath="CIDR" type="CPP_MODULE" version="4" />

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -424,9 +424,9 @@ namespace StockDory
         template<Limit::TimeType Type>
         bool OutOfTime() const
         {
-            if (!Limit.Timed) return false;
-
             if (ThreadType != Main) return false;
+
+            if (!Limit.Timed) return false;
 
             return Type == Limit::Actual ? ElapsedTime() > Limit. ActualTime
                                          : ElapsedTime() > Limit.OptimalTime;

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -426,6 +426,8 @@ namespace StockDory
         {
             if (!Limit.Timed) return false;
 
+            if (ThreadType != Main) return false;
+
             return Type == Limit::Actual ? ElapsedTime() > Limit. ActualTime
                                          : ElapsedTime() > Limit.OptimalTime;
         }


### PR DESCRIPTION
### 🎯 Summary

Timing should only be checked on main thread. There was an unintended regression introduced that caused timing to be checked on helper threads, which in turn would stop them immediately. This led to SMP being disabled in implementation while being advertised as enabled.

This will technically gain SMP Elo (due to unintended regression) but it's not a true Elo gain.

### 👏 Acknowledgements
NA

### 📈 ELO
NA