### PR TITLE
⚒️ FIX: Properly Synchronize Search Task Lifetime and Cleanup

### DIFF
--- a/src/Backend/ThreadPool.h
+++ b/src/Backend/ThreadPool.h
@@ -12,6 +12,50 @@
 
 using Block = drjit::blocked_range<uint8_t>;
 
+class ThreadedTask
+{
+
+    Task* Internal = nullptr;
+
+    public:
+    ThreadedTask() = default;
+
+    explicit ThreadedTask(Task* task) noexcept : Internal(task) {}
+
+    ~ThreadedTask() { Reset(); }
+
+    ThreadedTask(const ThreadedTask&) = delete;
+    ThreadedTask& operator =(const ThreadedTask&) = delete;
+
+    ThreadedTask(ThreadedTask&& other) noexcept : Internal(std::exchange(other.Internal, nullptr)) {}
+
+    ThreadedTask& operator =(ThreadedTask&& other) noexcept
+    {
+        if (this != &other) {
+            Reset();
+            Internal = std::exchange(other.Internal, nullptr);
+        }
+
+        return *this;
+    }
+
+    [[nodiscard]]
+    Task* Get() const noexcept { return Internal; }
+
+    [[nodiscard]]
+    explicit operator bool() const noexcept { return Internal != nullptr; }
+
+    void Wait() const { if (Internal != nullptr) task_wait(Internal); }
+
+    void Reset() noexcept
+    {
+        if (Internal == nullptr) return;
+
+        task_release(std::exchange(Internal, nullptr));
+    }
+
+};
+
 class ThreadPool
 {
 
@@ -38,10 +82,9 @@ class ThreadPool
     }
 
     template<typename F>
-    void Execute(F&& code)
+    ThreadedTask Execute(F&& code)
     {
-        Task* task = drjit::do_async(code, {}, Internal);
-        task_release(task);
+        return ThreadedTask(drjit::do_async(std::forward<F>(code), {}, Internal));
     }
 
     template<typename T, typename F>

--- a/src/Backend/Type/Move.h
+++ b/src/Backend/Type/Move.h
@@ -81,7 +81,7 @@ struct Move
     }
 
     [[nodiscard]]
-    constexpr bool operator==(const Move other) const
+    constexpr bool operator ==(const Move other) const
     {
         return Internal == other.Internal;
     }

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -7,6 +7,7 @@
 #define STOCKDORY_SEARCH_H
 
 #include <cmath>
+#include <ranges>
 
 #include "../Backend/Board.h"
 #include "../Backend/Misc.h"
@@ -98,8 +99,8 @@ namespace StockDory
         Array<Frame, Padding + MaxDepth> Internal {};
 
         public:
-              Frame& operator[](const size_t index)       { return Internal[index + Padding]; }
-        const Frame& operator[](const size_t index) const { return Internal[index + Padding]; }
+              Frame& operator [](const size_t index)       { return Internal[index + Padding]; }
+        const Frame& operator [](const size_t index) const { return Internal[index + Padding]; }
 
     };
 
@@ -1215,7 +1216,8 @@ namespace StockDory
 
         using ParallelTask = SearchTask<Parallel>;
 
-        std::vector<ParallelTask> Internal;
+        std::vector<ParallelTask> SearchTaskPool;
+        std::vector<ThreadedTask> ThreadTaskPool;
 
         size_t TaskCount = 0;
 
@@ -1230,17 +1232,37 @@ namespace StockDory
         {
             TaskCount = ThreadPool.Size() - 1;
 
-            Internal.reserve(TaskCount);
+            SearchTaskPool.reserve(TaskCount);
+            ThreadTaskPool.reserve(TaskCount);
         }
 
-        void Clear() { Internal.clear(); }
+        void Clear()
+        {
+            SearchTaskPool.clear();
+            ThreadTaskPool.clear();
+        }
 
         size_t Size() const { return TaskCount; }
 
         void Fill(Limit& l, Board& b, RepetitionStack& r, const uint8_t hmc)
-        { for (size_t i = 0; i < TaskCount; i++) Internal.emplace_back(l, b, r, hmc, i + 1); }
+        {
+            for (size_t i = 0; i < TaskCount; i++) SearchTaskPool.emplace_back(l, b, r, hmc, i + 1);
+        }
 
-        constexpr std::vector<ParallelTask>& operator &(){ return Internal; }
+        void Execute()
+        {
+            for (auto& task : SearchTaskPool) ThreadTaskPool.emplace_back(ThreadPool.Execute(
+                [&task] -> void { task.IterativeDeepening(); }
+            ));
+        }
+
+        void Stop()
+        {
+            for (auto &task : SearchTaskPool) task.Stop();
+            for (auto &task : ThreadTaskPool) task.Wait();
+        }
+
+        auto Tasks() const { return std::views::zip(SearchTaskPool, ThreadTaskPool); }
 
     };
 
@@ -1257,7 +1279,7 @@ namespace StockDory
             {
                 IterativeDeepeningIterationCompletionEvent event = e;
 
-                for (const auto& task : &ParallelTaskPool) event.Nodes += task.GetNodes();
+                for (const auto& [task, _] : ParallelTaskPool.Tasks()) event.Nodes += task.GetNodes();
 
                 return MainEventHandler::HandleIterativeDeepeningIterationCompletion(event);
             }
@@ -1313,13 +1335,7 @@ namespace StockDory
 
             if (ParallelTaskPool.Size()) {
                 ParallelTaskPool.Fill(l, b, r, hmc);
-
-                for (auto& task : &ParallelTaskPool) ThreadPool.Execute(
-                    [&task] -> void
-                    {
-                        task.IterativeDeepening();
-                    }
-                );
+                ParallelTaskPool.Execute();
             }
 
             MainTask = MainSearchTask(l, b, r, hmc, 0);
@@ -1332,12 +1348,10 @@ namespace StockDory
                     // The main thread is responsible for ensuring that it stops all the parallel tasks when it has
                     // concluded searching
                     if (ParallelTaskPool.Size()) {
-                        for (auto& task : &ParallelTaskPool) task.Stop();
-
-                        for (auto& task : &ParallelTaskPool) if (!task.Stopped()) Sleep(1);
+                        ParallelTaskPool.Stop();
+                        ParallelTaskPool.Clear();
                     }
 
-                    ParallelTaskPool.Clear();
                     Searching = false;
                 }
             );

--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -1293,13 +1293,11 @@ namespace StockDory
 
         static inline MainSearchTask MainTask;
 
-        static inline bool Searching = false;
+        static inline std::atomic_bool Searching = false;
 
         static void Run(Limit& l, Board& b, RepetitionStack& r, const uint8_t hmc)
         {
-            if (Searching) return;
-
-            Searching = true;
+            if (Searching.exchange(true, std::memory_order::acq_rel)) return;
 
             // Symmetric MultiProcessing (SMP):
             //
@@ -1352,7 +1350,8 @@ namespace StockDory
                         ParallelTaskPool.Clear();
                     }
 
-                    Searching = false;
+                    Searching.store(false, std::memory_order::release);
+                    Searching.notify_all();
                 }
             );
         }

--- a/src/Terminal/UCI/UCI.h
+++ b/src/Terminal/UCI/UCI.h
@@ -3,8 +3,8 @@
 // Licensed under LGPL-3.0.
 //
 
-#ifndef STOCKDORY_UCIINTERFACE_H
-#define STOCKDORY_UCIINTERFACE_H
+#ifndef STOCKDORY_UCI_H
+#define STOCKDORY_UCI_H
 
 #include <functional>
 #include <iostream>
@@ -30,7 +30,7 @@
 namespace StockDory
 {
 
-    class UCIInterface
+    class UCI
     {
 
         using UCISearch = ThreadedSearch<UCISearchEventHandler>;
@@ -177,8 +177,8 @@ namespace StockDory
         {
             if (!UCIPrompted) return;
 
-            if (UCISearch::Searching) UCISearch::MainTask.Stop();
-            while (UCISearch::Searching) Sleep(1);
+            if (UCISearch::Searching.load(std::memory_order::acquire)) UCISearch::MainTask.Stop();
+            UCISearch::Searching.wait(true, std::memory_order::acquire);
 
             Board           = {};
             Repetition      = {};
@@ -198,15 +198,17 @@ namespace StockDory
 
         static void Quit()
         {
-            if (UCISearch::Searching) UCISearch::MainTask.Stop();
-            while (UCISearch::Searching) Sleep(1);
+            if (UCISearch::Searching.load(std::memory_order::acquire)) UCISearch::MainTask.Stop();
+            UCISearch::Searching.wait(true, std::memory_order::acquire);
 
             Running = false;
         }
 
         static void Info(const Arguments& args)
         {
-            if (!UCIPrompted || UCISearch::Searching) return;
+            if (!UCIPrompted) return;
+
+            if (UCISearch::Searching.load(std::memory_order::acquire)) return;
 
             Board.LoadForEvaluation();
 
@@ -287,10 +289,12 @@ namespace StockDory
         {
             if (!UCIPrompted) return;
 
-            if (UCISearch::Searching) {
-                std::cerr << "ERROR: The engine is already searching" << std::endl;
-                return;
-            }
+            // if (UCISearch::Searching) {
+            //     std::cerr << "ERROR: The engine is already searching" << std::endl;
+            //     return;
+            // }
+
+            UCISearch::Searching.wait(true, std::memory_order::acquire);
 
             if (args.size() > 1 && strutil::compare_ignore_case(args[0], "perft")) {
                 const auto depth = static_cast<uint8_t>(std::stoull(args[1]));
@@ -338,4 +342,4 @@ namespace StockDory
 
 } // StockDory
 
-#endif //STOCKDORY_UCIINTERFACE_H
+#endif //STOCKDORY_UCI_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -8,7 +8,7 @@
 #include "Information.h"
 
 #include "Terminal/BenchHash.h"
-#include "Terminal/UCI/UCIInterface.h"
+#include "Terminal/UCI/UCI.h"
 
 void DisplayTitle()
 {
@@ -33,7 +33,7 @@ int main(const int argc, const char* argv[])
         }
     }
 
-    StockDory::UCIInterface::Launch();
+    StockDory::UCI::Launch();
 
     return EXIT_SUCCESS;
 }


### PR DESCRIPTION
### 🎯 Summary

This PR corrects the lifetime and synchronization of multi-threaded search tasks.

Previously, tasks submitted to the thread pool were effectively fire-and-forget. This meant StockDory had no reliable way to wait for helper searches to actually finish before destroying their associated search state. Search cleanup instead relied on observing the helper task's internal stopped state, which does not guarantee that the underlying thread-pool task has fully returned.

This PR introduces an RAII-managed `ThreadedTask` handle for asynchronously submitted work, allowing search tasks to be explicitly waited upon and safely released. The parallel search pool now retains these handles and waits for every helper search to finish before clearing its corresponding search state.

Search state synchronization has also been made explicit through an atomic `Searching` flag. A search now atomically claims the searching state, releases it only after all search cleanup has completed, and notifies any waiting UCI operations when teardown is complete. Commands which require the previous search to have completely finished can therefore wait directly on the search state rather than polling it.

Together, these changes ensure that:

* helper search tasks cannot outlive the objects containing their search state;
* search cleanup is complete before the engine advertises itself as ready for another search;
* a subsequent `go` cannot race the cleanup of the previous search;
* `ucinewgame` and `quit` can safely wait for search termination without polling;
* task ownership and release are handled deterministically through RAII.

The changes also include a minor cleanup renaming `UCIInterface` to `UCI`.

The resulting search remains bench-identical.

### 👏 Acknowledgements

NA

### 📈 ELO

NA