### PR TITLE
⚒️ FIX: Eliminate Transposition Table Data Races

### DIFF
--- a/src/Engine/Search.h
+++ b/src/Engine/Search.h
@@ -635,10 +635,10 @@ namespace StockDory
             // exists a transposition entry - if the entry is valid, depending on the quality of the entry, we can
             // return the evaluation from the entry. Even if the entry isn't of sufficient quality to return directly,
             // we can still search the move in the entry first, since it most likely is the best move in the position
-            SearchTranspositionEntry& ttEntry      = TT[hash];
-            Move                      ttMove       = {};
-            bool                      ttHit        = false;
-            Score                     ttEvaluation = None;
+            SearchTranspositionEntry ttEntry      = TT[hash];
+            Move                     ttMove       = {};
+            bool                     ttHit        = false;
+            Score                    ttEvaluation = None;
 
             if (ttEntry.Type != Invalid && ttEntry.Hash == CompressHash(hash)) {
                 ttHit  = true;
@@ -1052,7 +1052,7 @@ namespace StockDory
             //
             // As long as the search has not stopped, we should try to insert/replace the transposition table entry
             // with the new entry as it is most likely more relevant than the old entry
-            if (Status != SearchThreadStatus::Stopped) TryReplaceTT(ttEntry, ttEntryNew);
+            if (Status != SearchThreadStatus::Stopped) TryReplaceTT(hash, ttEntryNew);
 
             return bestEvaluation;
         }
@@ -1078,7 +1078,7 @@ namespace StockDory
 
                 const ZobristHash hash = Board.Zobrist();
 
-                const SearchTranspositionEntry& ttEntry = TT[hash];
+                const SearchTranspositionEntry ttEntry = TT[hash];
 
                 if (ttEntry.Hash == CompressHash(hash)) {
                     const Score ttEvaluation = DecompressScore(ttEntry.Evaluation, ply);
@@ -1200,13 +1200,15 @@ namespace StockDory
             return (Evaluation::Evaluate(Color, ThreadId) * weightedMaterial) / MaterialScalingQuantization;
         }
 
-        static void TryReplaceTT(SearchTranspositionEntry& pEntry, const SearchTranspositionEntry nEntry)
+        static void TryReplaceTT(const ZobristHash hash, const SearchTranspositionEntry nEntry)
         {
+            const SearchTranspositionEntry pEntry = TT[hash];
+
             if (nEntry.Type == Exact || nEntry.Hash != pEntry.Hash ||
                (pEntry.Type == Alpha &&
                 nEntry.Type == Beta) ||
                 nEntry.Depth > pEntry.Depth - TTReplacementDepthMargin)
-                pEntry = nEntry;
+                TT[hash] = nEntry;
         }
 
     };

--- a/src/Engine/TranspositionTable.h
+++ b/src/Engine/TranspositionTable.h
@@ -8,7 +8,6 @@
 
 #include <vector>
 
-#include "../Backend/ThreadPool.h"
 #include "../Backend/Type/Zobrist.h"
 
 #include "../External/fastrange.h"
@@ -81,11 +80,7 @@ namespace StockDory
 
         void Prefetch(const ZobristHash hash) const
         {
-            __builtin_prefetch(
-                static_cast<const void*>(&Internal[fastrange64(hash, Count)]),
-                0,
-                3
-            );
+            __builtin_prefetch(static_cast<const void*>(&Internal[fastrange64(hash, Count)]), 0, 3);
         }
 
         [[nodiscard]]

--- a/src/Engine/TranspositionTable.h
+++ b/src/Engine/TranspositionTable.h
@@ -67,8 +67,6 @@ namespace StockDory
         void Clear()
         {
             Internal = std::vector<Atomic>(Count);
-
-            for (Atomic& entry : Internal) entry.store(T {}, std::memory_order::relaxed);
         }
 
         Reference operator [](const ZobristHash hash)

--- a/src/Engine/TranspositionTable.h
+++ b/src/Engine/TranspositionTable.h
@@ -20,8 +20,36 @@ namespace StockDory
     class TranspositionTable
     {
 
-        std::vector<T> Internal;
-        size_t         Count = 0;
+        static_assert(std::is_trivially_copyable_v<T>, "Transposition table entries must be trivially copyable");
+        static_assert(std::atomic<T>::is_always_lock_free, "Transposition table entries must use lock-free atomics");
+
+        using Atomic = std::atomic<T>;
+
+        class Reference
+        {
+
+            Atomic* Internal;
+
+            public:
+            explicit Reference(Atomic& entry) : Internal(&entry) {}
+
+            // ReSharper disable once CppNonExplicitConversionOperator
+            operator T() const
+            {
+                return Internal->load(std::memory_order::relaxed);
+            }
+
+            Reference& operator =(const T& value)
+            {
+                Internal->store(value, std::memory_order::relaxed);
+
+                return *this;
+            }
+
+        };
+
+        std::vector<Atomic> Internal;
+        size_t              Count = 0;
 
         public:
         explicit TranspositionTable(const size_t bytes)
@@ -31,30 +59,32 @@ namespace StockDory
 
         void Resize(const size_t bytes)
         {
-            Count = bytes / sizeof(T);
+            Count = bytes / sizeof(Atomic);
 
             Clear();
         }
 
         void Clear()
         {
-            Internal = std::vector<T>(Count);
+            Internal = std::vector<Atomic>(Count);
+
+            for (Atomic& entry : Internal) entry.store(T {}, std::memory_order::relaxed);
         }
 
-        T& operator [](const ZobristHash hash)
+        Reference operator [](const ZobristHash hash)
         {
-            return Internal[fastrange64(hash, Count)];
+            return Reference(Internal[fastrange64(hash, Count)]);
         }
 
-        const T& operator [](const ZobristHash hash) const
+        T operator [](const ZobristHash hash) const
         {
-            return Internal[fastrange64(hash, Count)];
+            return Internal[fastrange64(hash, Count)].load(std::memory_order::relaxed);
         }
 
         void Prefetch(const ZobristHash hash) const
         {
             __builtin_prefetch(
-                static_cast<const void*>(reinterpret_cast<const char*>(&Internal[fastrange64(hash, Count)])),
+                static_cast<const void*>(&Internal[fastrange64(hash, Count)]),
                 0,
                 3
             );


### PR DESCRIPTION
### 🎯 Summary

This PR eliminates data-race undefined behavior in the transposition table during multi-threaded search. Previously, search threads read and wrote entries concurrently without any safeguards, allowing unsynchronized access to the same entry, at times leading to entry corruption or worst. 

While this was rare, it hurt the robustness of StockDory and as such was something that had to be fixed. 

Transposition table entries now use lock-free `std::atomic<T>` storage with relaxed loads and stores. Replacement checks reload the current entry before applying the existing replacement policy and atomically storing the new entry.

### 👏 Acknowledgements

NA

### 📈 ELO

### 4 Threads

**[STC](https://verdict.shaheryarsohail.com/test/1/)**:
```
Elo   | 1.21 +- 2.24 (95%)
SPRT  | 10.0+0.10s Threads=4 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 27880 W: 6485 L: 6388 D: 15007
Penta | [189, 3365, 6752, 3428, 206]
```
**[LTC](https://verdict.shaheryarsohail.com/test/2/)**:
```
Elo   | 2.05 +- 2.63 (95%)
SPRT  | 60.0+0.60s Threads=4 Hash=512MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 17954 W: 3913 L: 3807 D: 10234
Penta | [62, 2092, 4570, 2184, 69]
```